### PR TITLE
Feature/sphere segment voxel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+lib/
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 lib/
 build/
+__pycache__/
+*.pyc
+*.pyd
+*.egg-info/
+.pytest_cache/
+test_dataset/
+*.rf3
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,17 @@ if(BUILD_TESTS MATCHES ON)
 
   set_target_properties(AccessorTest PROPERTIES FOLDER "Tests")
 
+  add_executable(SphericalTest ${PROJECT_SOURCE_DIR}/tests/spherical_test.cpp)
+  target_include_directories(SphericalTest PUBLIC include PRIVATE src)
+  if (MSVC)
+    target_link_libraries(SphericalTest glm libRadFiled3D GTest::gtest_main)
+  else()
+    target_link_libraries(SphericalTest glm libRadFiled3D GTest::gtest_main stdc++fs)
+  endif()
+  set_property(TARGET SphericalTest PROPERTY CXX_STANDARD ${CMAKE_CXX_STANDARD})
+  gtest_discover_tests(SphericalTest)
+  set_target_properties(SphericalTest PROPERTIES FOLDER "Tests")
+
   include(GoogleTest)
 endif()
 

--- a/include/RadFiled3D/Voxel.hpp
+++ b/include/RadFiled3D/Voxel.hpp
@@ -4,6 +4,7 @@
 #include <glm/vec3.hpp>
 #include "RadFiled3D/helpers/Typing.hpp"
 #include <cstring>
+#include <cmath>
 #include <span>
 
 
@@ -777,6 +778,266 @@ namespace RadFiled3D {
 
 		virtual void set_data(void* data) override {
 			memcpy(this->data, data, this->histogram_definition.bins * sizeof(float));
+		}
+	};
+
+	class SphericalVoxel : public ScalarVoxel<float> {
+	public:
+#pragma pack(push, 4)
+		struct SphericalDefinition : VoxelBaseHeader {
+			size_t phi_segments;
+			size_t theta_segments;
+
+			SphericalDefinition(size_t phi_segments = 0, size_t theta_segments = 0) : phi_segments(phi_segments), theta_segments(theta_segments) {}
+		};
+#pragma pack(pop)
+
+	protected:
+		SphericalDefinition spherical_definition;
+
+		/** Compute flat index from phi/theta grid indices */
+		inline size_t calc_segment_idx(size_t phi_idx, size_t theta_idx) const {
+			return theta_idx * this->spherical_definition.phi_segments + phi_idx;
+		}
+
+		/** Compute flat index from phi/theta in standard spherical coordinates (linear mapping)
+		* @param phi Azimuthal angle in radians [0, 2*pi]
+		* @param theta Polar angle in radians [0, pi]
+		*/
+		inline size_t calc_segment_idx_by_coord(float phi, float theta) const {
+			const float pi = 3.14159265358979323846f;
+			// Wrap phi to [0, 2*pi]
+			if (phi < 0.f) phi += 2.f * pi;
+			if (phi >= 2.f * pi) phi -= 2.f * pi;
+			// Clamp theta to [0, pi]
+			if (theta < 0.f) theta = 0.f;
+			if (theta > pi) theta = pi;
+
+			size_t phi_idx = static_cast<size_t>(phi / (2.f * pi) * this->spherical_definition.phi_segments);
+			size_t theta_idx = static_cast<size_t>(theta / pi * this->spherical_definition.theta_segments);
+
+			if (phi_idx >= this->spherical_definition.phi_segments) phi_idx = this->spherical_definition.phi_segments - 1;
+			if (theta_idx >= this->spherical_definition.theta_segments) theta_idx = this->spherical_definition.theta_segments - 1;
+
+			return calc_segment_idx(phi_idx, theta_idx);
+		}
+
+	public:
+		/** Create a new SphericalVoxel with an empty data buffer */
+		SphericalVoxel() noexcept : ScalarVoxel<float>(nullptr), spherical_definition(SphericalDefinition()) {}
+
+		/** Create a new SphericalVoxel with the given data buffer */
+		SphericalVoxel(size_t phi_segments, size_t theta_segments, float* buffer) : ScalarVoxel<float>(buffer), spherical_definition(phi_segments, theta_segments) {}
+
+		/** Move constructor */
+		SphericalVoxel(SphericalVoxel&& buffer) noexcept : ScalarVoxel<float>(buffer.data), spherical_definition(buffer.spherical_definition) {
+			buffer.data = nullptr;
+		}
+
+		/** Copy constructor */
+		SphericalVoxel(const SphericalVoxel& buffer) noexcept : ScalarVoxel<float>(buffer.data), spherical_definition(buffer.spherical_definition) {}
+
+		/** Returns the total number of segments (phi * theta) */
+		inline size_t get_total_segments() const { return this->spherical_definition.phi_segments * this->spherical_definition.theta_segments; }
+
+		/** Returns the number of phi segments */
+		inline size_t get_phi_segments() const { return this->spherical_definition.phi_segments; }
+
+		/** Returns the number of theta segments */
+		inline size_t get_theta_segments() const { return this->spherical_definition.theta_segments; }
+
+		/** Returns a span containing all segment data */
+		inline std::span<float> get_segments_data() const {
+			return std::span<float>(this->data, this->get_total_segments());
+		}
+
+		/** Access a segment value by spherical coordinates
+		* @param phi The phi coordinate in radians
+		* @param theta The theta coordinate in radians
+		* @return Reference to the segment value
+		*/
+		inline float& get_value_by_coord(float phi, float theta) const {
+			return this->data[this->calc_segment_idx_by_coord(phi, theta)];
+		}
+
+		/** Access a segment value by grid indices
+		* @param phi_idx The phi index [0, phi_segments - 1]
+		* @param theta_idx The theta index [0, theta_segments - 1]
+		* @return Reference to the segment value
+		*/
+		inline float& get_value(size_t phi_idx, size_t theta_idx) const {
+			return this->data[this->calc_segment_idx(phi_idx, theta_idx)];
+		}
+
+		/** Returns the type of the voxel as a string */
+		virtual std::string get_type() const override {
+			return "spherical";
+		}
+
+		/** Returns the size of the voxel object in bytes, excluding the data */
+		virtual size_t get_voxel_bytes() const override { return sizeof(SphericalVoxel); }
+
+		/** Returns the size of the data in bytes */
+		virtual size_t get_bytes() const override { return sizeof(float) * this->get_total_segments(); }
+
+		/** Returns the reference to the first element in the data buffer */
+		inline float& get_data() const { return *this->data; }
+
+		/** Returns a raw pointer to the data buffer */
+		virtual void* get_raw() const override { return this->data; }
+
+		/** Default assignment operator */
+		SphericalVoxel& operator=(const SphericalVoxel& other) = default;
+
+		/** Inplace add two SphericalVoxels */
+		SphericalVoxel& operator+=(const SphericalVoxel& other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] += other.data[i];
+			return *this;
+		}
+
+		SphericalVoxel operator+(const SphericalVoxel& other) const {
+			SphericalVoxel result = *this;
+			result += other;
+			return result;
+		}
+
+		/** Inplace subtract two SphericalVoxels */
+		SphericalVoxel& operator-=(const SphericalVoxel& other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] -= other.data[i];
+			return *this;
+		}
+
+		SphericalVoxel operator-(const SphericalVoxel& other) const {
+			SphericalVoxel result = *this;
+			result -= other;
+			return result;
+		}
+
+		/** Inplace multiply two SphericalVoxels */
+		SphericalVoxel& operator*=(const SphericalVoxel& other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] *= other.data[i];
+			return *this;
+		}
+
+		SphericalVoxel operator*(const SphericalVoxel& other) const {
+			SphericalVoxel result = *this;
+			result *= other;
+			return result;
+		}
+
+		/** Inplace divide two SphericalVoxels */
+		SphericalVoxel& operator/=(const SphericalVoxel& other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++) {
+				if (other.data[i] == 0.f) {
+					this->data[i] = 0.f;
+					continue;
+				}
+				this->data[i] /= other.data[i];
+			}
+			return *this;
+		}
+
+		SphericalVoxel operator/(const SphericalVoxel& other) const {
+			SphericalVoxel result = *this;
+			result /= other;
+			return result;
+		}
+
+		/** Scalar arithmetic operators */
+		SphericalVoxel& operator+=(float other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] += other;
+			return *this;
+		}
+
+		SphericalVoxel& operator-=(float other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] -= other;
+			return *this;
+		}
+
+		SphericalVoxel& operator*=(float other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] *= other;
+			return *this;
+		}
+
+		SphericalVoxel& operator/=(float other) {
+			for (size_t i = 0; i < this->get_total_segments(); i++)
+				this->data[i] /= other;
+			return *this;
+		}
+
+		/** Returns the header for serialization */
+		virtual VoxelBaseHeader get_header() const override {
+			return VoxelBaseHeader(sizeof(SphericalDefinition), (void*)&this->spherical_definition);
+		}
+
+		/** Initializes the Voxel from a header block (deserialization) */
+		virtual void init_from_header(const void* header) override {
+			SphericalDefinition* sph_def = (SphericalDefinition*)header;
+			this->spherical_definition = *sph_def;
+		}
+
+		/** Adds a value at the given spherical direction
+		* @param phi The phi coordinate in radians
+		* @param theta The theta coordinate in radians
+		* @param value The value to add
+		*/
+		void add_value(float phi, float theta, float value = 1.f) {
+			this->data[this->calc_segment_idx_by_coord(phi, theta)] += value;
+		}
+
+		/** Clears all segments to 0 */
+		void clear() {
+			std::fill(this->data, this->data + this->get_total_segments(), 0.0f);
+		}
+	};
+
+	/** Owning version of the SphericalVoxel class. Owns the data buffer and frees it on destruction. */
+	class OwningSphericalVoxel : public SphericalVoxel {
+	public:
+		OwningSphericalVoxel(size_t phi_segments = 0, size_t theta_segments = 0) : SphericalVoxel(phi_segments, theta_segments, (phi_segments * theta_segments > 0) ? new float[phi_segments * theta_segments]() : nullptr) {}
+
+		OwningSphericalVoxel(size_t phi_segments, size_t theta_segments, float* buffer) : SphericalVoxel(phi_segments, theta_segments, (phi_segments * theta_segments > 0) ? new float[phi_segments * theta_segments] : nullptr) {
+			if (phi_segments * theta_segments > 0)
+				memcpy(this->data, buffer, phi_segments * theta_segments * sizeof(float));
+		}
+
+		OwningSphericalVoxel(const OwningSphericalVoxel& buffer) : SphericalVoxel(buffer) {
+			size_t total = this->get_total_segments();
+			if (total > 0) {
+				this->data = new float[total];
+				memcpy(this->data, buffer.data, total * sizeof(float));
+			}
+		}
+
+		OwningSphericalVoxel(OwningSphericalVoxel&& buffer) noexcept : SphericalVoxel(buffer) {
+			size_t total = this->get_total_segments();
+			if (total > 0) {
+				this->data = new float[total];
+				memcpy(this->data, buffer.data, total * sizeof(float));
+			}
+		}
+
+		~OwningSphericalVoxel() {
+			if (this->data != nullptr)
+				delete[] this->data;
+		}
+
+		virtual void init_from_header(const void* header) override {
+			SphericalDefinition* sph_def = (SphericalDefinition*)header;
+			this->spherical_definition = *sph_def;
+			if (this->data != nullptr)
+				delete[] this->data;
+			this->data = new float[sph_def->phi_segments * sph_def->theta_segments];
+		}
+
+		virtual void set_data(void* data) override {
+			memcpy(this->data, data, this->get_total_segments() * sizeof(float));
 		}
 	};
 };

--- a/include/RadFiled3D/Voxel.hpp
+++ b/include/RadFiled3D/Voxel.hpp
@@ -896,6 +896,10 @@ namespace RadFiled3D {
 			return *this;
 		}
 
+		/** Adds two SphericalVoxels together
+		* @param other The other SphericalVoxel to add
+		* @return The sum of the two SphericalVoxels
+		*/
 		SphericalVoxel operator+(const SphericalVoxel& other) const {
 			SphericalVoxel result = *this;
 			result += other;
@@ -909,6 +913,10 @@ namespace RadFiled3D {
 			return *this;
 		}
 
+		/** Subtracts a SphericalVoxel from another
+		* @param other The other SphericalVoxel to subtract
+		* @return The difference of the two SphericalVoxels
+		*/
 		SphericalVoxel operator-(const SphericalVoxel& other) const {
 			SphericalVoxel result = *this;
 			result -= other;
@@ -922,6 +930,10 @@ namespace RadFiled3D {
 			return *this;
 		}
 
+		/** Multiplies two SphericalVoxels together
+		* @param other The other SphericalVoxel to multiply
+		* @return The product of the two SphericalVoxels
+		*/
 		SphericalVoxel operator*(const SphericalVoxel& other) const {
 			SphericalVoxel result = *this;
 			result *= other;
@@ -940,36 +952,52 @@ namespace RadFiled3D {
 			return *this;
 		}
 
+		/** Divides a SphericalVoxel by another
+		* @param other The other SphericalVoxel to divide by
+		* @return The quotient of the two SphericalVoxels
+		*/
 		SphericalVoxel operator/(const SphericalVoxel& other) const {
 			SphericalVoxel result = *this;
 			result /= other;
 			return result;
 		}
 
-		/** Scalar arithmetic operators */
+		/** Inplace adds a scalar value to all segments
+		* @param other The scalar value to add
+		* @return The modified SphericalVoxel
+		*/
 		SphericalVoxel& operator+=(float other) {
 			for (size_t i = 0; i < this->get_total_segments(); i++)
 				this->data[i] += other;
 			return *this;
 		}
 
+		/** Inplace subtracts a scalar value from all segments */
 		SphericalVoxel& operator-=(float other) {
 			for (size_t i = 0; i < this->get_total_segments(); i++)
 				this->data[i] -= other;
 			return *this;
 		}
 
+		/** Inplace multiplies all segments by a scalar value */
 		SphericalVoxel& operator*=(float other) {
 			for (size_t i = 0; i < this->get_total_segments(); i++)
 				this->data[i] *= other;
 			return *this;
 		}
 
+		/** Inplace divides all segments by a scalar value */
 		SphericalVoxel& operator/=(float other) {
 			for (size_t i = 0; i < this->get_total_segments(); i++)
 				this->data[i] /= other;
 			return *this;
 		}
+
+		/** Non-inplace scalar arithmetic operators */
+		SphericalVoxel operator+(float other) const { SphericalVoxel r = *this; r += other; return r; }
+		SphericalVoxel operator-(float other) const { SphericalVoxel r = *this; r -= other; return r; }
+		SphericalVoxel operator*(float other) const { SphericalVoxel r = *this; r *= other; return r; }
+		SphericalVoxel operator/(float other) const { SphericalVoxel r = *this; r /= other; return r; }
 
 		/** Returns the header for serialization */
 		virtual VoxelBaseHeader get_header() const override {

--- a/include/RadFiled3D/helpers/Typing.hpp
+++ b/include/RadFiled3D/helpers/Typing.hpp
@@ -23,6 +23,7 @@ namespace RadFiled3D {
 			Vec3,
 			Vec4,
 			Hist,
+			Spherical,
 			UInt64,
 			UInt32,
 			Byte

--- a/include/RadFiled3D/storage/FieldSerializer.hpp
+++ b/include/RadFiled3D/storage/FieldSerializer.hpp
@@ -58,6 +58,7 @@ namespace RadFiled3D {
 				* @param unit The unit of the histogram
 				*/
 				static void add_hist_layer(std::shared_ptr<VoxelBuffer> field, const std::string& layer, size_t bytes_per_element, float max_energy_eV, const std::string& unit, void* header_data);
+				static void add_spherical_layer(std::shared_ptr<VoxelBuffer> field, const std::string& layer, size_t bytes_per_element, const std::string& unit, void* header_data);
 			public:
 				BinayFieldBlockHandler() = default;
 

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -1226,25 +1226,13 @@ PYBIND11_MODULE(RadFiled3D, m) {
         .def("get_phi_segments", &SphericalVoxel::get_phi_segments)
         .def("get_theta_segments", &SphericalVoxel::get_theta_segments)
         .def("get_total_segments", &SphericalVoxel::get_total_segments)
-        .def("get_segments_data", [](const SphericalVoxel& a) {
-            auto data = a.get_segments_data();
-            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
-            return py::array_t<float>(
-                { static_cast<size_t>(data.size()) },
-                { sizeof(float) },
-                data.data(),
-                cap
-            );
+        .def("get_segments_data", [](std::shared_ptr<SphericalVoxel> a) {
+            auto data = a->get_segments_data();
+            return create_py_array<float>(data.data(), data.size(), a, false);
         }, py::return_value_policy::reference)
-        .def("get_data", [](const SphericalVoxel& a) {
-            auto data = a.get_segments_data();
-            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
-            return py::array_t<float>(
-                { a.get_theta_segments(), a.get_phi_segments() },
-                { sizeof(float) * a.get_phi_segments(), sizeof(float) },
-                data.data(),
-                cap
-            );
+        .def("get_data", [](std::shared_ptr<SphericalVoxel> a) {
+            auto data = a->get_segments_data();
+            return create_py_array_generic<float>(data.data(), glm::uvec2(a->get_phi_segments(), a->get_theta_segments()), a, false, sizeof(float));
         }, py::return_value_policy::reference)
         .def("get_value", &SphericalVoxel::get_value, py::arg("phi_idx"), py::arg("theta_idx"), py::return_value_policy::reference)
         .def("get_value_by_coord", &SphericalVoxel::get_value_by_coord, py::arg("phi"), py::arg("theta"), py::return_value_policy::reference)
@@ -1262,25 +1250,13 @@ PYBIND11_MODULE(RadFiled3D, m) {
         .def("get_phi_segments", &OwningSphericalVoxel::get_phi_segments)
         .def("get_theta_segments", &OwningSphericalVoxel::get_theta_segments)
         .def("get_total_segments", &OwningSphericalVoxel::get_total_segments)
-        .def("get_segments_data", [](const OwningSphericalVoxel& a) {
-            auto data = a.get_segments_data();
-            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
-            return py::array_t<float>(
-                { static_cast<size_t>(data.size()) },
-                { sizeof(float) },
-                data.data(),
-                cap
-            );
+        .def("get_segments_data", [](std::shared_ptr<OwningSphericalVoxel> a) {
+            auto data = a->get_segments_data();
+            return create_py_array<float>(data.data(), data.size(), a, false);
         }, py::return_value_policy::reference)
-        .def("get_data", [](const OwningSphericalVoxel& a) {
-            auto data = a.get_segments_data();
-            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
-            return py::array_t<float>(
-                { a.get_theta_segments(), a.get_phi_segments() },
-                { sizeof(float) * a.get_phi_segments(), sizeof(float) },
-                data.data(),
-                cap
-            );
+        .def("get_data", [](std::shared_ptr<OwningSphericalVoxel> a) {
+            auto data = a->get_segments_data();
+            return create_py_array_generic<float>(data.data(), glm::uvec2(a->get_phi_segments(), a->get_theta_segments()), a, false, sizeof(float));
         }, py::return_value_policy::reference)
         .def("add_value", &OwningSphericalVoxel::add_value, py::arg("phi"), py::arg("theta"), py::arg("value") = 1.f)
         .def("clear", &OwningSphericalVoxel::clear)
@@ -1384,7 +1360,10 @@ PYBIND11_MODULE(RadFiled3D, m) {
             }, py::arg("name"), py::arg("unit"), py::arg("dtype"))
             .def("add_histogram_layer", [](VoxelBuffer& self, const std::string& name, size_t bins, float bin_width, const std::string& unit) {
                 self.add_custom_layer<HistogramVoxel>(name, HistogramVoxel(bins, bin_width, nullptr), 0.f, unit);
-            }, py::arg("name"), py::arg("bins"), py::arg("bin_width"), py::arg("unit"));
+            }, py::arg("name"), py::arg("bins"), py::arg("bin_width"), py::arg("unit"))
+            .def("add_spherical_layer", [](VoxelBuffer& self, const std::string& name, size_t phi_segments, size_t theta_segments, const std::string& unit) {
+                self.add_custom_layer<SphericalVoxel>(name, SphericalVoxel(phi_segments, theta_segments, nullptr), 0.f, unit);
+            }, py::arg("name"), py::arg("phi_segments"), py::arg("theta_segments"), py::arg("unit"));
 
         py::class_<VoxelGridBuffer, std::shared_ptr<VoxelGridBuffer>, VoxelBuffer>(m, "VoxelGridBuffer")
             .def("get_voxel_counts", &VoxelGridBuffer::get_voxel_counts)

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -102,6 +102,8 @@ std::shared_ptr<IVoxel> encapsulate_voxel(IVoxel* vx) {
         return VOXEL_CAPSULE(vx, ScalarVoxel<glm::vec4>);
     case Typing::DType::Hist:
         return VOXEL_CAPSULE(vx, HistogramVoxel);
+    case Typing::DType::Spherical:
+        return VOXEL_CAPSULE(vx, SphericalVoxel);
     case Typing::DType::UInt64:
         return VOXEL_CAPSULE(vx, ScalarVoxel<uint64_t>);
     case Typing::DType::UInt32:
@@ -1220,6 +1222,75 @@ PYBIND11_MODULE(RadFiled3D, m) {
 			}
 		);
 
+    py::class_<SphericalVoxel, std::shared_ptr<SphericalVoxel>, IVoxel>(m, "SphericalVoxel")
+        .def("get_phi_segments", &SphericalVoxel::get_phi_segments)
+        .def("get_theta_segments", &SphericalVoxel::get_theta_segments)
+        .def("get_total_segments", &SphericalVoxel::get_total_segments)
+        .def("get_segments_data", [](const SphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { static_cast<size_t>(data.size()) },
+                { sizeof(float) },
+                data.data(),
+                cap
+            );
+        }, py::return_value_policy::reference)
+        .def("get_data", [](const SphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { a.get_theta_segments(), a.get_phi_segments() },
+                { sizeof(float) * a.get_phi_segments(), sizeof(float) },
+                data.data(),
+                cap
+            );
+        }, py::return_value_policy::reference)
+        .def("get_value", &SphericalVoxel::get_value, py::arg("phi_idx"), py::arg("theta_idx"), py::return_value_policy::reference)
+        .def("get_value_by_coord", &SphericalVoxel::get_value_by_coord, py::arg("phi"), py::arg("theta"), py::return_value_policy::reference)
+        .def("add_value", &SphericalVoxel::add_value, py::arg("phi"), py::arg("theta"), py::arg("value") = 1.f)
+        .def("clear", &SphericalVoxel::clear)
+        .def(py::self == py::self)
+        .def("__repr__",
+            [](const SphericalVoxel& a) {
+                return "<RadFiled3D.SphericalVoxel (" + std::to_string(a.get_phi_segments()) + "phi x " + std::to_string(a.get_theta_segments()) + "theta)>";
+            }
+        );
+
+    py::class_<OwningSphericalVoxel, std::shared_ptr<OwningSphericalVoxel>, SphericalVoxel>(m, "OwningSphericalVoxel")
+        .def(py::init<size_t, size_t>(), py::arg("phi_segments"), py::arg("theta_segments"))
+        .def("get_phi_segments", &OwningSphericalVoxel::get_phi_segments)
+        .def("get_theta_segments", &OwningSphericalVoxel::get_theta_segments)
+        .def("get_total_segments", &OwningSphericalVoxel::get_total_segments)
+        .def("get_segments_data", [](const OwningSphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { static_cast<size_t>(data.size()) },
+                { sizeof(float) },
+                data.data(),
+                cap
+            );
+        }, py::return_value_policy::reference)
+        .def("get_data", [](const OwningSphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { a.get_theta_segments(), a.get_phi_segments() },
+                { sizeof(float) * a.get_phi_segments(), sizeof(float) },
+                data.data(),
+                cap
+            );
+        }, py::return_value_policy::reference)
+        .def("add_value", &OwningSphericalVoxel::add_value, py::arg("phi"), py::arg("theta"), py::arg("value") = 1.f)
+        .def("clear", &OwningSphericalVoxel::clear)
+        .def(py::self == py::self)
+        .def("__repr__",
+            [](const OwningSphericalVoxel& a) {
+                return "<RadFiled3D.OwningSphericalVoxel (" + std::to_string(a.get_phi_segments()) + "phi x " + std::to_string(a.get_theta_segments()) + "theta)>";
+            }
+        );
+
     py::enum_<GridTracerAlgorithm>(m, "GridTracerAlgorithm")
         .value("SAMPLING", GridTracerAlgorithm::SAMPLING)
 		.value("BRESENHAM", GridTracerAlgorithm::BRESENHAM)
@@ -1341,6 +1412,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
                         return VOXEL_REFERENCE(&self.get_voxel_flat<ScalarVoxel<glm::vec4>>(layer_name, idx));
                     case Typing::DType::Hist:
                         return VOXEL_REFERENCE(&self.get_voxel_flat<HistogramVoxel>(layer_name, idx));
+                    case Typing::DType::Spherical:
+                        return VOXEL_REFERENCE(&self.get_voxel_flat<SphericalVoxel>(layer_name, idx));
                     case Typing::DType::UInt64:
                         return VOXEL_REFERENCE(&self.get_voxel_flat<ScalarVoxel<uint64_t>>(layer_name, idx));
                     case Typing::DType::UInt32:
@@ -1370,6 +1443,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
                         return VOXEL_REFERENCE(&self.get_voxel<ScalarVoxel<glm::vec4>>(layer_name, x, y, z));
                     case Typing::DType::Hist:
                         return VOXEL_REFERENCE(&self.get_voxel<HistogramVoxel>(layer_name, x, y, z));
+                    case Typing::DType::Spherical:
+                        return VOXEL_REFERENCE(&self.get_voxel<SphericalVoxel>(layer_name, x, y, z));
                     case Typing::DType::UInt64:
                         return VOXEL_REFERENCE(&self.get_voxel<ScalarVoxel<uint64_t>>(layer_name, x, y, z));
                     case Typing::DType::UInt32:
@@ -1399,6 +1474,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
                         return VOXEL_REFERENCE(&self.get_voxel_by_coord<ScalarVoxel<glm::vec4>>(layer_name, x, y, z));
                     case Typing::DType::Hist:
                         return VOXEL_REFERENCE(&self.get_voxel_by_coord<HistogramVoxel>(layer_name, x, y, z));
+                    case Typing::DType::Spherical:
+                        return VOXEL_REFERENCE(&self.get_voxel_by_coord<SphericalVoxel>(layer_name, x, y, z));
                     case Typing::DType::UInt64:
                         return VOXEL_REFERENCE(&self.get_voxel_by_coord<ScalarVoxel<uint64_t>>(layer_name, x, y, z));
                     case Typing::DType::UInt32:
@@ -1467,6 +1544,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
                         return VOXEL_REFERENCE(&self.get_voxel_flat<ScalarVoxel<glm::vec4>>(idx));
                     case Typing::DType::Hist:
                         return VOXEL_REFERENCE(&self.get_voxel_flat<HistogramVoxel>(idx));
+                    case Typing::DType::Spherical:
+                        return VOXEL_REFERENCE(&self.get_voxel_flat<SphericalVoxel>(idx));
                     case Typing::DType::UInt64:
                         return VOXEL_REFERENCE(&self.get_voxel_flat<ScalarVoxel<uint64_t>>(idx));
                     case Typing::DType::UInt32:

--- a/python/stubs/RadFiled3D.pyi
+++ b/python/stubs/RadFiled3D.pyi
@@ -378,6 +378,97 @@ class HistogramVoxel(Voxel):
         ...
 
 
+class SphericalVoxel(Voxel):
+    def get_phi_segments(self) -> int:
+        """
+        Returns the number of phi (azimuthal) segments.
+
+        :return: The number of phi segments.
+        """
+        ...
+
+    def get_theta_segments(self) -> int:
+        """
+        Returns the number of theta (polar) segments.
+
+        :return: The number of theta segments.
+        """
+        ...
+
+    def get_total_segments(self) -> int:
+        """
+        Returns the total number of segments (phi * theta).
+
+        :return: The total number of segments.
+        """
+        ...
+
+    def get_segments_data(self) -> np.ndarray:
+        """
+        Returns all segment values as a flat numpy array.
+
+        :return: Flat array of shape (phi_segments * theta_segments,).
+        """
+        ...
+
+    def get_data(self) -> np.ndarray:
+        """
+        Returns segment values as a 2D numpy array.
+
+        :return: Array of shape (theta_segments, phi_segments).
+        """
+        ...
+
+    def get_value(self, phi_idx: int, theta_idx: int) -> float:
+        """
+        Access a segment value by grid indices.
+
+        :param phi_idx: The phi index [0, phi_segments - 1].
+        :param theta_idx: The theta index [0, theta_segments - 1].
+        :return: The segment value.
+        """
+        ...
+
+    def get_value_by_coord(self, phi: float, theta: float) -> float:
+        """
+        Access a segment value by spherical coordinates.
+
+        :param phi: Azimuthal angle in radians [0, 2*pi].
+        :param theta: Polar angle in radians [0, pi].
+        :return: The segment value.
+        """
+        ...
+
+    def add_value(self, phi: float, theta: float, value: float = 1.0) -> None:
+        """
+        Adds a value at the given spherical direction.
+
+        :param phi: Azimuthal angle in radians [0, 2*pi].
+        :param theta: Polar angle in radians [0, pi].
+        :param value: The value to add (default 1.0).
+        """
+        ...
+
+    def clear(self) -> None:
+        """
+        Clears all segments to 0.
+        """
+        ...
+
+    def __eq__(self, value: "SphericalVoxel") -> bool: ...
+
+
+class OwningSphericalVoxel(SphericalVoxel):
+    def __init__(self, phi_segments: int, theta_segments: int) -> None:
+        """
+        Creates a new OwningSphericalVoxel with the given segment resolution.
+
+        :param phi_segments: Number of azimuthal segments.
+        :param theta_segments: Number of polar segments.
+        """
+        ...
+
+
 class VoxelBuffer(object):
     def get_voxel_count(self) -> int:
         """

--- a/src/FieldAccessor.cpp
+++ b/src/FieldAccessor.cpp
@@ -289,10 +289,21 @@ IVoxel* RadFiled3D::Storage::V1::FileParser::createVoxelFromBuffer(char* data_bu
 		break;
 	case Typing::DType::Hist:
 		break;
+	case Typing::DType::Spherical:
+		break;
 	}
 
 	if (voxel == nullptr && dtype == Typing::DType::Hist) {
 		OwningHistogramVoxel* vx = new OwningHistogramVoxel();
+		if (voxel_header_data != nullptr) {
+			vx->init_from_header(voxel_header_data);
+		}
+		vx->set_data(data_buffer);
+		voxel = vx;
+	}
+
+	if (voxel == nullptr && dtype == Typing::DType::Spherical) {
+		OwningSphericalVoxel* vx = new OwningSphericalVoxel();
 		if (voxel_header_data != nullptr) {
 			vx->init_from_header(voxel_header_data);
 		}

--- a/src/FieldSerializer.cpp
+++ b/src/FieldSerializer.cpp
@@ -101,7 +101,8 @@ VoxelLayer* Storage::V1::BinayFieldBlockHandler::deserializeLayer(char* data, si
 	Typing::DType dtype = Typing::Helper::get_dtype(std::string(layer_desc.dtype));
 	VoxelLayer* layer = nullptr;
 	HistogramVoxel hist_template;
-	
+	SphericalVoxel sph_template;
+
 	switch (dtype)
 	{
 	case Typing::DType::Float:
@@ -136,6 +137,11 @@ VoxelLayer* Storage::V1::BinayFieldBlockHandler::deserializeLayer(char* data, si
 		if (header_data != nullptr)
 			hist_template.init_from_header(header_data);
 		layer = VoxelLayer::ConstructFromBufferRaw<float, HistogramVoxel>(std::string(layer_desc.unit), voxel_count, layer_desc.statistical_error, data + mem_pos, true, hist_template);
+		break;
+	case Typing::DType::Spherical:
+		if (header_data != nullptr)
+			sph_template.init_from_header(header_data);
+		layer = VoxelLayer::ConstructFromBufferRaw<float, SphericalVoxel>(std::string(layer_desc.unit), voxel_count, layer_desc.statistical_error, data + mem_pos, true, sph_template);
 		break;
 	case Typing::DType::UInt64:
 #if defined(__x86_64__) || defined(_M_X64)
@@ -200,6 +206,9 @@ std::shared_ptr<VoxelBuffer> Storage::V1::BinayFieldBlockHandler::deserializeCha
 			case Typing::DType::Hist:
 				Storage::V1::BinayFieldBlockHandler::add_hist_layer(destination, std::string(layer_desc.name), layer_desc.bytes_per_element, 0, layer_desc.unit, header_data);
 				break;
+			case Typing::DType::Spherical:
+				Storage::V1::BinayFieldBlockHandler::add_spherical_layer(destination, std::string(layer_desc.name), layer_desc.bytes_per_element, layer_desc.unit, header_data);
+				break;
 			case Typing::DType::UInt64:
 #if defined(__x86_64__) || defined(_M_X64)
 				destination->add_layer<uint64_t>(std::string(layer_desc.name), 0, layer_desc.unit);
@@ -234,6 +243,14 @@ void Storage::V1::BinayFieldBlockHandler::add_hist_layer(std::shared_ptr<VoxelBu
 	if (header_data != nullptr)
 		hist.init_from_header(header_data);
 	field->add_custom_layer<HistogramVoxel, float>(layer, hist, 0.f, unit);
+}
+
+void Storage::V1::BinayFieldBlockHandler::add_spherical_layer(std::shared_ptr<VoxelBuffer> field, const std::string& layer, size_t bytes_per_element, const std::string& unit, void* header_data)
+{
+	SphericalVoxel sph;
+	if (header_data != nullptr)
+		sph.init_from_header(header_data);
+	field->add_custom_layer<SphericalVoxel, float>(layer, sph, 0.f, unit);
 }
 
 std::shared_ptr<IRadiationField> RadFiled3D::Storage::V1::BinayFieldBlockHandler::deserializeField(std::istream& buffer) const

--- a/src/RadiationFieldStore.cpp
+++ b/src/RadiationFieldStore.cpp
@@ -294,6 +294,9 @@ void Storage::V1::FieldStore::join(std::shared_ptr<IRadiationField> target, std:
 				case Typing::DType::Hist:
 					target_channel->merge_voxel_buffer<HistogramVoxel>(layer_name, *channel.second.get(), ExporterHelpers::get_join_function<HistogramVoxel, float>(join_mode, ratio));
 					break;
+				case Typing::DType::Spherical:
+					target_channel->merge_voxel_buffer<SphericalVoxel>(layer_name, *channel.second.get(), ExporterHelpers::get_join_function<SphericalVoxel, float>(join_mode, ratio));
+					break;
 			}
 		}
 	}

--- a/src/Typing.cpp
+++ b/src/Typing.cpp
@@ -53,6 +53,9 @@ Typing::DType Typing::Helper::get_dtype(const std::string& dtype)
 	if (dtype == std::string("histogram")) {
 		return Typing::DType::Hist;
 	}
+	if (dtype == std::string("spherical")) {
+		return Typing::DType::Spherical;
+	}
 
 	std::string vec_prefix = "glm::vec<";
 	const std::string struct_prefix = "struct ";
@@ -110,6 +113,8 @@ size_t RadFiled3D::Typing::Helper::get_bytes_of_dtype(Typing::DType dtype)
 	case Typing::DType::Byte:
 		return sizeof(uint8_t);
 	case Typing::DType::Hist:
+		return sizeof(float);
+	case Typing::DType::Spherical:
 		return sizeof(float);
 	default:
 		throw std::runtime_error("Unknown data type");

--- a/src/VoxelBuffer.cpp
+++ b/src/VoxelBuffer.cpp
@@ -230,6 +230,14 @@ VoxelBuffer& VoxelBuffer::operator+=(const VoxelBuffer& other)
 				*hist1 += *hist2;
 			}
 			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph1 = (SphericalVoxel*)(layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				auto sph2 = (SphericalVoxel*)(other_layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				*sph1 += *sph2;
+			}
+			break;
 		}
 	}
 
@@ -304,6 +312,14 @@ VoxelBuffer& VoxelBuffer::operator*=(const VoxelBuffer& other) {
 				auto hist1 = (HistogramVoxel*)(layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
 				auto hist2 = (HistogramVoxel*)(other_layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
 				*hist1 *= *hist2;
+			}
+			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph1 = (SphericalVoxel*)(layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				auto sph2 = (SphericalVoxel*)(other_layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				*sph1 *= *sph2;
 			}
 			break;
 		}
@@ -382,6 +398,14 @@ VoxelBuffer& VoxelBuffer::operator-=(const VoxelBuffer& other) {
 				*hist1 -= *hist2;
 			}
 			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph1 = (SphericalVoxel*)(layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				auto sph2 = (SphericalVoxel*)(other_layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				*sph1 -= *sph2;
+			}
+			break;
 		}
 	}
 
@@ -456,6 +480,14 @@ VoxelBuffer& VoxelBuffer::operator/=(const VoxelBuffer& other) {
 				auto hist1 = (HistogramVoxel*)(layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
 				auto hist2 = (HistogramVoxel*)(other_layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
 				*hist1 /= *hist2;
+			}
+			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph1 = (SphericalVoxel*)(layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				auto sph2 = (SphericalVoxel*)(other_layer_info->second.voxels + i * layer_info->second.bytes_per_voxel);
+				*sph1 /= *sph2;
 			}
 			break;
 		}
@@ -548,6 +580,13 @@ VoxelBuffer& VoxelBuffer::operator+=(const float& scalar) {
 				*hist += scalar;
 			}
 			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph = (SphericalVoxel*)(layer_info.voxels + i * layer_info.bytes_per_voxel);
+				*sph += scalar;
+			}
+			break;
 		}
 	}
 	return *this;
@@ -636,6 +675,13 @@ VoxelBuffer& VoxelBuffer::operator-=(const float& scalar) {
 			{
 				auto hist = (HistogramVoxel*)(layer_info.voxels + i * layer_info.bytes_per_voxel);
 				*hist -= scalar;
+			}
+			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph = (SphericalVoxel*)(layer_info.voxels + i * layer_info.bytes_per_voxel);
+				*sph -= scalar;
 			}
 			break;
 		}
@@ -728,6 +774,13 @@ VoxelBuffer& VoxelBuffer::operator*=(const float& scalar) {
 				*hist *= scalar;
 			}
 			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph = (SphericalVoxel*)(layer_info.voxels + i * layer_info.bytes_per_voxel);
+				*sph *= scalar;
+			}
+			break;
 		}
 	}
 	return *this;
@@ -816,6 +869,13 @@ VoxelBuffer& VoxelBuffer::operator/=(const float& scalar) {
 			{
 				auto hist = (HistogramVoxel*)(layer_info.voxels + i * layer_info.bytes_per_voxel);
 				*hist /= scalar;
+			}
+			break;
+		case Typing::DType::Spherical:
+			for (size_t i = 0; i < this->voxel_count; i++)
+			{
+				auto sph = (SphericalVoxel*)(layer_info.voxels + i * layer_info.bytes_per_voxel);
+				*sph /= scalar;
 			}
 			break;
 		}

--- a/tests/spherical_test.cpp
+++ b/tests/spherical_test.cpp
@@ -1,245 +1,487 @@
 #include "RadFiled3D/Voxel.hpp"
 #include "RadFiled3D/RadiationField.hpp"
 #include "RadFiled3D/storage/RadiationFieldStore.hpp"
+#include "RadFiled3D/storage/FieldAccessor.hpp"
 #include "RadFiled3D/storage/Types.hpp"
 #include "gtest/gtest.h"
 #include <cmath>
 #include <fstream>
 #include <cstdio>
-#include <iostream>
 
 using namespace RadFiled3D;
 using namespace RadFiled3D::Storage;
 
-TEST(SphericalVoxelTest, Construction) {
-	float buffer[72] = { 0.f };
-	SphericalVoxel voxel(12, 6, buffer);
+namespace {
+	// Fixture class for tests that create .rf3 files — ensures cleanup via TearDown
+	class SphericalVoxelStorage : public ::testing::Test {
+	protected:
+		void TearDown() override {
+			std::vector<std::string> files = {
+				"test_spherical.rf3", "test_spherical_join.rf3",
+				"test_spherical_accessor.rf3", "test_spherical_metadata.rf3",
+				"test_spherical_mixed.rf3"
+			};
+			for (auto& file : files) {
+				if (std::ifstream(file).good())
+					std::remove(file.c_str());
+			}
+		}
+	};
 
-	EXPECT_EQ(voxel.get_phi_segments(), 12);
-	EXPECT_EQ(voxel.get_theta_segments(), 6);
-	EXPECT_EQ(voxel.get_total_segments(), 72);
-	EXPECT_EQ(voxel.get_bytes(), sizeof(float) * 72);
-	EXPECT_EQ(voxel.get_type(), "spherical");
-}
+	// === Voxel Unit Tests ===
 
-TEST(SphericalVoxelTest, DefaultConstruction) {
-	SphericalVoxel voxel;
+	TEST(SphericalVoxelTest, Construction) {
+		float buffer[72] = { 0.f };
+		SphericalVoxel voxel(12, 6, buffer);
 
-	EXPECT_EQ(voxel.get_phi_segments(), 0);
-	EXPECT_EQ(voxel.get_theta_segments(), 0);
-	EXPECT_EQ(voxel.get_total_segments(), 0);
-}
-
-TEST(SphericalVoxelTest, AccessByIndex) {
-	float buffer[72] = { 0.f };
-	SphericalVoxel voxel(12, 6, buffer);
-
-	// Use add_value to set data, then read back with get_value
-	buffer[2 * 12 + 3] = 0.5f;  // set raw buffer directly
-	EXPECT_FLOAT_EQ(voxel.get_value(3, 2), 0.5f);  // read through voxel
-}
-
-TEST(SphericalVoxelTest, AddValue) {
-	float buffer[72] = { 0.f };
-	SphericalVoxel voxel(12, 6, buffer);
-
-	voxel.add_value(1.0f, 0.5f, 3.0f);
-	// Verify the exact segment got the value
-	EXPECT_FLOAT_EQ(voxel.get_value_by_coord(1.0f, 0.5f), 3.0f);
-
-	// Verify total sum is correct (only one segment was written)
-	float sum = 0.f;
-	for (size_t i = 0; i < 72; i++)
-		sum += buffer[i];
-	EXPECT_FLOAT_EQ(sum, 3.0f);
-}
-
-
-TEST(SphericalVoxelTest, Clear) {
-	float buffer[4] = { 1.f, 3.f, 2.f, 4.f };
-	SphericalVoxel voxel(2, 2, buffer);
-
-	voxel.clear();
-	for (size_t i = 0; i < 4; i++)
-		EXPECT_FLOAT_EQ(buffer[i], 0.f);
-}
-
-TEST(SphericalVoxelTest, InplaceAdd) {
-	float buf_a[4] = { 1.f, 2.f, 3.f, 4.f };
-	float buf_b[4] = { 0.5f, 0.5f, 0.5f, 0.5f };
-	SphericalVoxel a(2, 2, buf_a);
-	SphericalVoxel b(2, 2, buf_b);
-
-	a += b;
-	EXPECT_FLOAT_EQ(buf_a[0], 1.5f);
-	EXPECT_FLOAT_EQ(buf_a[1], 2.5f);
-	EXPECT_FLOAT_EQ(buf_a[2], 3.5f);
-	EXPECT_FLOAT_EQ(buf_a[3], 4.5f);
-}
-
-TEST(SphericalVoxelTest, ScalarDivide) {
-	float buffer[4] = { 2.f, 4.f, 6.f, 8.f };
-	SphericalVoxel voxel(2, 2, buffer);
-
-	voxel /= 2.f;
-	EXPECT_FLOAT_EQ(buffer[0], 1.f);
-	EXPECT_FLOAT_EQ(buffer[1], 2.f);
-	EXPECT_FLOAT_EQ(buffer[2], 3.f);
-	EXPECT_FLOAT_EQ(buffer[3], 4.f);
-}
-
-TEST(SphericalVoxelTest, Header) {
-	float buffer[72] = { 0.f };
-	SphericalVoxel voxel(12, 6, buffer);
-
-	auto header = voxel.get_header();
-	EXPECT_EQ(header.header_bytes, sizeof(SphericalVoxel::SphericalDefinition));
-
-	SphericalVoxel::SphericalDefinition* def = (SphericalVoxel::SphericalDefinition*)header.header;
-	EXPECT_EQ(def->phi_segments, 12);
-	EXPECT_EQ(def->theta_segments, 6);
-}
-
-TEST(SphericalVoxelTest, InitFromHeader) {
-	SphericalVoxel voxel;
-	SphericalVoxel::SphericalDefinition def(8, 4);
-
-	voxel.init_from_header(&def);
-	EXPECT_EQ(voxel.get_phi_segments(), 8);
-	EXPECT_EQ(voxel.get_theta_segments(), 4);
-	EXPECT_EQ(voxel.get_total_segments(), 32);
-}
-
-TEST(SphericalVoxelTest, OwningConstruction) {
-	OwningSphericalVoxel voxel(12, 6);
-
-	EXPECT_EQ(voxel.get_phi_segments(), 12);
-	EXPECT_EQ(voxel.get_total_segments(), 72);
-	EXPECT_NE(voxel.get_raw(), nullptr);
-
-	// Should be zero-initialized or at least accessible
-	voxel.add_value(1.0f, 0.5f, 5.0f);
-	float sum = 0.f;
-	for (auto val : voxel.get_segments_data())
-		sum += val;
-	EXPECT_FLOAT_EQ(sum, 5.0f);
-}
-
-TEST(SphericalVoxelTest, OwningCopy) {
-	OwningSphericalVoxel a(2, 2);
-	float* a_data = (float*)a.get_raw();
-	a_data[0] = 1.f; a_data[1] = 2.f; a_data[2] = 3.f; a_data[3] = 4.f;
-
-	OwningSphericalVoxel b(a);
-	float* b_data = (float*)b.get_raw();
-
-	// Data should be equal but at different addresses
-	EXPECT_NE(a_data, b_data);
-	EXPECT_FLOAT_EQ(b_data[0], 1.f);
-	EXPECT_FLOAT_EQ(b_data[3], 4.f);
-}
-
-TEST(SphericalVoxelTest, StoreAndLoad) {
-	const std::string filename = "test_spherical.rf3";
-
-	// Create a field with a spherical layer
-	auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.1f));
-	std::shared_ptr<VoxelGridBuffer> channel = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("test_channel"));
-
-	// Add a spherical layer with 12 phi x 6 theta segments
-	channel->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(12, 6, nullptr), 0.f, "");
-	// Also add a simple float layer to verify mixed types work
-	channel->add_layer<float>("doserate", 0.f, "Gy/s");
-
-	// Set some values in the spherical layer
-	SphericalVoxel& sph = channel->get_voxel<SphericalVoxel>("angular", 0, 5, 0);
-	for (size_t i = 0; i < 72; i++)
-		sph.get_segments_data()[i] = static_cast<float>(i);
-
-	// Set a value on the diagonal
-	for (size_t x = 0; x < 10; x++) {
-		SphericalVoxel& diag = channel->get_voxel<SphericalVoxel>("angular", x, x, x);
-		for (size_t i = 0; i < 72; i++)
-			diag.get_segments_data()[i] = 99.f;
+		EXPECT_EQ(voxel.get_phi_segments(), 12);
+		EXPECT_EQ(voxel.get_theta_segments(), 6);
+		EXPECT_EQ(voxel.get_total_segments(), 72);
+		EXPECT_EQ(voxel.get_bytes(), sizeof(float) * 72);
+		EXPECT_EQ(voxel.get_type(), "spherical");
 	}
 
-	// Set doserate too
-	channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0) = 42.f;
+	TEST(SphericalVoxelTest, DefaultConstruction) {
+		SphericalVoxel voxel;
 
-	// --- Print before store ---
-	std::cout << "\n=== BEFORE STORE ===" << std::endl;
-	std::cout << "Field: " << field->get_voxel_counts().x << "x" << field->get_voxel_counts().y << "x" << field->get_voxel_counts().z << " voxels" << std::endl;
-	std::cout << "Voxel dimensions: " << field->get_voxel_dimensions().x << "m" << std::endl;
-	std::cout << "Channels: ";
-	for (auto& ch : field->get_channels()) std::cout << ch.first << " ";
-	std::cout << std::endl;
-	std::cout << "Layers: angular (spherical " << sph.get_phi_segments() << "x" << sph.get_theta_segments() << "), doserate (float)" << std::endl;
-	std::cout << "\nVoxel (0,5,0) angular - first 12 segments (phi row 0):" << std::endl;
-	for (size_t i = 0; i < 12; i++)
-		std::cout << "  [phi=" << i << ",theta=0] = " << sph.get_segments_data()[i] << std::endl;
-	std::cout << "Voxel (0,5,0) doserate = " << channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0).get_data() << std::endl;
-	std::cout << "\nDiagonal voxel (3,3,3) angular - first 6 segments:" << std::endl;
-	SphericalVoxel& diag_print = channel->get_voxel<SphericalVoxel>("angular", 3, 3, 3);
-	for (size_t i = 0; i < 6; i++)
-		std::cout << "  [" << i << "] = " << diag_print.get_segments_data()[i] << std::endl;
-
-	// Create metadata and store
-	auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
-		Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
-			1000, "test_geom", "test_physics",
-			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
-				glm::vec3(0.f, 0.f, -1.f), glm::vec3(0.f, 0.f, 1.f), 15000.f, "test_tube"
-			)
-		),
-		Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
-	);
-
-	FieldStore::store(field, metadata, filename);
-
-	// Load and verify
-	auto loaded_field = std::static_pointer_cast<CartesianRadiationField>(FieldStore::load(filename));
-	EXPECT_EQ(loaded_field->get_voxel_counts(), glm::uvec3(10));
-
-	std::shared_ptr<VoxelGridBuffer> loaded_channel = std::static_pointer_cast<VoxelGridBuffer>(loaded_field->get_channel("test_channel"));
-
-	// --- Print after load ---
-	std::cout << "\n=== AFTER LOAD ===" << std::endl;
-	std::cout << "Field: " << loaded_field->get_voxel_counts().x << "x" << loaded_field->get_voxel_counts().y << "x" << loaded_field->get_voxel_counts().z << " voxels" << std::endl;
-	std::cout << "Layers in channel: ";
-	for (auto& l : loaded_channel->get_layers()) std::cout << l << " ";
-	std::cout << std::endl;
-
-	// Verify doserate
-	float loaded_doserate = loaded_channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0).get_data();
-	std::cout << "\nVoxel (0,5,0) doserate = " << loaded_doserate << std::endl;
-	EXPECT_FLOAT_EQ(loaded_doserate, 42.f);
-
-	// Verify spherical voxel at (0,5,0)
-	SphericalVoxel& loaded_sph = loaded_channel->get_voxel<SphericalVoxel>("angular", 0, 5, 0);
-	std::cout << "Voxel (0,5,0) angular: phi_segments=" << loaded_sph.get_phi_segments() << " theta_segments=" << loaded_sph.get_theta_segments() << std::endl;
-	std::cout << "Voxel (0,5,0) angular - first 12 segments (phi row 0):" << std::endl;
-	for (size_t i = 0; i < 12; i++)
-		std::cout << "  [phi=" << i << ",theta=0] = " << loaded_sph.get_segments_data()[i] << std::endl;
-
-	EXPECT_EQ(loaded_sph.get_phi_segments(), 12);
-	EXPECT_EQ(loaded_sph.get_theta_segments(), 6);
-	for (size_t i = 0; i < 72; i++)
-		EXPECT_FLOAT_EQ(loaded_sph.get_segments_data()[i], static_cast<float>(i));
-
-	// Verify diagonal voxels
-	std::cout << "\nDiagonal voxel (3,3,3) angular - first 6 segments:" << std::endl;
-	SphericalVoxel& loaded_diag_print = loaded_channel->get_voxel<SphericalVoxel>("angular", 3, 3, 3);
-	for (size_t i = 0; i < 6; i++)
-		std::cout << "  [" << i << "] = " << loaded_diag_print.get_segments_data()[i] << std::endl;
-
-	for (size_t x = 0; x < 10; x++) {
-		SphericalVoxel& loaded_diag = loaded_channel->get_voxel<SphericalVoxel>("angular", x, x, x);
-		for (size_t i = 0; i < 72; i++)
-			EXPECT_FLOAT_EQ(loaded_diag.get_segments_data()[i], 99.f);
+		EXPECT_EQ(voxel.get_phi_segments(), 0);
+		EXPECT_EQ(voxel.get_theta_segments(), 0);
+		EXPECT_EQ(voxel.get_total_segments(), 0);
 	}
 
-	std::cout << "\n=== STORE/LOAD MATCH ===" << std::endl;
+	TEST(SphericalVoxelTest, AccessByIndex) {
+		float buffer[72] = { 0.f };
+		SphericalVoxel voxel(12, 6, buffer);
 
-	// Cleanup
-	std::remove(filename.c_str());
+		buffer[2 * 12 + 3] = 0.5f;
+		EXPECT_FLOAT_EQ(voxel.get_value(3, 2), 0.5f);
+	}
+
+	TEST(SphericalVoxelTest, AddValue) {
+		float buffer[72] = { 0.f };
+		SphericalVoxel voxel(12, 6, buffer);
+
+		voxel.add_value(1.0f, 0.5f, 3.0f);
+		EXPECT_FLOAT_EQ(voxel.get_value_by_coord(1.0f, 0.5f), 3.0f);
+
+		float sum = 0.f;
+		for (size_t i = 0; i < 72; i++)
+			sum += buffer[i];
+		EXPECT_FLOAT_EQ(sum, 3.0f);
+	}
+
+	TEST(SphericalVoxelTest, Clear) {
+		float buffer[4] = { 1.f, 3.f, 2.f, 4.f };
+		SphericalVoxel voxel(2, 2, buffer);
+
+		voxel.clear();
+		for (size_t i = 0; i < 4; i++)
+			EXPECT_FLOAT_EQ(buffer[i], 0.f);
+	}
+
+	TEST(SphericalVoxelTest, InplaceAdd) {
+		float buf_a[4] = { 1.f, 2.f, 3.f, 4.f };
+		float buf_b[4] = { 0.5f, 0.5f, 0.5f, 0.5f };
+		SphericalVoxel a(2, 2, buf_a);
+		SphericalVoxel b(2, 2, buf_b);
+
+		a += b;
+		EXPECT_FLOAT_EQ(buf_a[0], 1.5f);
+		EXPECT_FLOAT_EQ(buf_a[1], 2.5f);
+		EXPECT_FLOAT_EQ(buf_a[2], 3.5f);
+		EXPECT_FLOAT_EQ(buf_a[3], 4.5f);
+	}
+
+	TEST(SphericalVoxelTest, ScalarDivide) {
+		float buffer[4] = { 2.f, 4.f, 6.f, 8.f };
+		SphericalVoxel voxel(2, 2, buffer);
+
+		voxel /= 2.f;
+		EXPECT_FLOAT_EQ(buffer[0], 1.f);
+		EXPECT_FLOAT_EQ(buffer[1], 2.f);
+		EXPECT_FLOAT_EQ(buffer[2], 3.f);
+		EXPECT_FLOAT_EQ(buffer[3], 4.f);
+	}
+
+	TEST(SphericalVoxelTest, Header) {
+		float buffer[72] = { 0.f };
+		SphericalVoxel voxel(12, 6, buffer);
+
+		auto header = voxel.get_header();
+		EXPECT_EQ(header.header_bytes, sizeof(SphericalVoxel::SphericalDefinition));
+
+		SphericalVoxel::SphericalDefinition* def = (SphericalVoxel::SphericalDefinition*)header.header;
+		EXPECT_EQ(def->phi_segments, 12);
+		EXPECT_EQ(def->theta_segments, 6);
+	}
+
+	TEST(SphericalVoxelTest, InitFromHeader) {
+		SphericalVoxel voxel;
+		SphericalVoxel::SphericalDefinition def(8, 4);
+
+		voxel.init_from_header(&def);
+		EXPECT_EQ(voxel.get_phi_segments(), 8);
+		EXPECT_EQ(voxel.get_theta_segments(), 4);
+		EXPECT_EQ(voxel.get_total_segments(), 32);
+	}
+
+	TEST(SphericalVoxelTest, OwningConstruction) {
+		OwningSphericalVoxel voxel(12, 6);
+
+		EXPECT_EQ(voxel.get_phi_segments(), 12);
+		EXPECT_EQ(voxel.get_total_segments(), 72);
+		EXPECT_NE(voxel.get_raw(), nullptr);
+
+		voxel.add_value(1.0f, 0.5f, 5.0f);
+		float sum = 0.f;
+		for (auto val : voxel.get_segments_data())
+			sum += val;
+		EXPECT_FLOAT_EQ(sum, 5.0f);
+	}
+
+	TEST(SphericalVoxelTest, OwningCopy) {
+		OwningSphericalVoxel a(2, 2);
+		float* a_data = (float*)a.get_raw();
+		a_data[0] = 1.f; a_data[1] = 2.f; a_data[2] = 3.f; a_data[3] = 4.f;
+
+		OwningSphericalVoxel b(a);
+		float* b_data = (float*)b.get_raw();
+
+		EXPECT_NE(a_data, b_data);
+		EXPECT_FLOAT_EQ(b_data[0], 1.f);
+		EXPECT_FLOAT_EQ(b_data[3], 4.f);
+	}
+
+	// === Storage Tests (use fixture for cleanup) ===
+
+	TEST_F(SphericalVoxelStorage, StoreAndLoad) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.1f));
+		std::shared_ptr<VoxelGridBuffer> channel = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("test_channel"));
+
+		channel->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(12, 6, nullptr), 0.f, "");
+		channel->add_layer<float>("doserate", 0.f, "Gy/s");
+
+		SphericalVoxel& sph = channel->get_voxel<SphericalVoxel>("angular", 0, 5, 0);
+		for (size_t i = 0; i < 72; i++)
+			sph.get_segments_data()[i] = static_cast<float>(i);
+
+		for (size_t x = 0; x < 10; x++) {
+			SphericalVoxel& diag = channel->get_voxel<SphericalVoxel>("angular", x, x, x);
+			for (size_t i = 0; i < 72; i++)
+				diag.get_segments_data()[i] = 99.f;
+		}
+
+		channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0) = 42.f;
+
+		auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
+				1000, "test_geom", "test_physics",
+				Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
+					glm::vec3(0.f, 0.f, -1.f), glm::vec3(0.f, 0.f, 1.f), 15000.f, "test_tube"
+				)
+			),
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
+		);
+
+		FieldStore::store(field, metadata, "test_spherical.rf3");
+
+		auto loaded_field = std::static_pointer_cast<CartesianRadiationField>(FieldStore::load("test_spherical.rf3"));
+		EXPECT_EQ(loaded_field->get_voxel_counts(), glm::uvec3(10));
+
+		std::shared_ptr<VoxelGridBuffer> loaded_channel = std::static_pointer_cast<VoxelGridBuffer>(loaded_field->get_channel("test_channel"));
+
+		EXPECT_FLOAT_EQ(loaded_channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0).get_data(), 42.f);
+
+		SphericalVoxel& loaded_sph = loaded_channel->get_voxel<SphericalVoxel>("angular", 0, 5, 0);
+		EXPECT_EQ(loaded_sph.get_phi_segments(), 12);
+		EXPECT_EQ(loaded_sph.get_theta_segments(), 6);
+		for (size_t i = 0; i < 72; i++)
+			EXPECT_FLOAT_EQ(loaded_sph.get_segments_data()[i], static_cast<float>(i));
+
+		for (size_t x = 0; x < 10; x++) {
+			SphericalVoxel& loaded_diag = loaded_channel->get_voxel<SphericalVoxel>("angular", x, x, x);
+			for (size_t i = 0; i < 72; i++)
+				EXPECT_FLOAT_EQ(loaded_diag.get_segments_data()[i], 99.f);
+		}
+	}
+
+	TEST(SphericalVoxelTest, FieldCopy) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.1f));
+		std::shared_ptr<VoxelGridBuffer> channel = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("test_channel"));
+
+		channel->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(12, 6, nullptr), 0.f, "");
+		channel->add_layer<float>("doserate", 5.f, "Gy/s");
+
+		SphericalVoxel& sph = channel->get_voxel<SphericalVoxel>("angular", 5, 5, 5);
+		for (size_t i = 0; i < 72; i++)
+			sph.get_segments_data()[i] = static_cast<float>(i + 1);
+
+		auto copy = std::dynamic_pointer_cast<CartesianRadiationField>(field->copy());
+		std::shared_ptr<VoxelGridBuffer> copy_channel = std::static_pointer_cast<VoxelGridBuffer>(copy->get_channel("test_channel"));
+
+		EXPECT_EQ(copy->get_voxel_counts(), field->get_voxel_counts());
+		EXPECT_EQ(copy->get_voxel_dimensions(), field->get_voxel_dimensions());
+
+		SphericalVoxel& copy_sph = copy_channel->get_voxel<SphericalVoxel>("angular", 5, 5, 5);
+		EXPECT_EQ(copy_sph.get_phi_segments(), 12);
+		EXPECT_EQ(copy_sph.get_theta_segments(), 6);
+		for (size_t i = 0; i < 72; i++)
+			EXPECT_FLOAT_EQ(copy_sph.get_segments_data()[i], static_cast<float>(i + 1));
+
+		// Deep copy: modifying copy doesn't affect original
+		copy_sph.get_segments_data()[0] = 999.f;
+		EXPECT_FLOAT_EQ(sph.get_segments_data()[0], 1.f);
+
+		EXPECT_FLOAT_EQ(copy_channel->get_voxel<ScalarVoxel<float>>("doserate", 5, 5, 5).get_data(), 5.f);
+	}
+
+	TEST(SphericalVoxelTest, VoxelBufferOperators) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.1f));
+		std::shared_ptr<VoxelGridBuffer> channel = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("ch1"));
+
+		channel->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(4, 2, nullptr), 0.f, "");
+		channel->add_layer<float>("doserate", 10.f, "Gy/s");
+
+		SphericalVoxel& sph = channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0);
+		for (size_t i = 0; i < 8; i++)
+			sph.get_segments_data()[i] = static_cast<float>(i);
+
+		VoxelBuffer* original = static_cast<VoxelBuffer*>(channel->copy());
+		EXPECT_FLOAT_EQ(static_cast<VoxelGridBuffer*>(original)->get_voxel<SphericalVoxel>("angular", 0, 0, 0).get_segments_data()[3], 3.f);
+
+		*channel += *original;
+		EXPECT_FLOAT_EQ(channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0).get_segments_data()[3], 6.f);
+		EXPECT_FLOAT_EQ(channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 0, 0).get_data(), 20.f);
+
+		*channel -= *original;
+		EXPECT_FLOAT_EQ(channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0).get_segments_data()[3], 3.f);
+		EXPECT_FLOAT_EQ(channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 0, 0).get_data(), 10.f);
+
+		*channel *= *original;
+		EXPECT_FLOAT_EQ(channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0).get_segments_data()[3], 9.f);
+		EXPECT_FLOAT_EQ(channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 0, 0).get_data(), 100.f);
+
+		*channel /= *channel;
+		EXPECT_FLOAT_EQ(channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0).get_segments_data()[0], 0.f);
+		EXPECT_FLOAT_EQ(channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0).get_segments_data()[3], 1.f);
+		EXPECT_FLOAT_EQ(channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 0, 0).get_data(), 1.f);
+
+		delete original;
+	}
+
+	TEST(SphericalVoxelTest, GridAccess3D) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(0.5f), glm::vec3(0.1f));
+		std::shared_ptr<VoxelGridBuffer> channel = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("ch1"));
+
+		channel->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(6, 3, nullptr), 0.f, "");
+
+		channel->get_voxel<SphericalVoxel>("angular", 0, 0, 0).add_value(0.f, 0.f, 1.f);
+		channel->get_voxel<SphericalVoxel>("angular", 4, 3, 2).add_value(1.f, 0.5f, 5.f);
+		channel->get_voxel<SphericalVoxel>("angular", 2, 2, 2).add_value(3.14f, 1.57f, 10.f);
+
+		size_t flat_432 = 2 * 5 * 5 + 3 * 5 + 4;
+		size_t flat_222 = 2 * 5 * 5 + 2 * 5 + 2;
+
+		float sum_0 = 0.f, sum_432 = 0.f, sum_222 = 0.f;
+		for (auto val : channel->get_voxel_flat<SphericalVoxel>("angular", 0).get_segments_data()) sum_0 += val;
+		for (auto val : channel->get_voxel_flat<SphericalVoxel>("angular", flat_432).get_segments_data()) sum_432 += val;
+		for (auto val : channel->get_voxel_flat<SphericalVoxel>("angular", flat_222).get_segments_data()) sum_222 += val;
+
+		EXPECT_FLOAT_EQ(sum_0, 1.f);
+		EXPECT_FLOAT_EQ(sum_432, 5.f);
+		EXPECT_FLOAT_EQ(sum_222, 10.f);
+
+		float sum_empty = 0.f;
+		for (auto val : channel->get_voxel<SphericalVoxel>("angular", 1, 1, 1).get_segments_data()) sum_empty += val;
+		EXPECT_FLOAT_EQ(sum_empty, 0.f);
+	}
+
+	TEST_F(SphericalVoxelStorage, JoinFields) {
+		auto create_field = [](float value) {
+			auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.5f));
+			std::shared_ptr<VoxelGridBuffer> ch = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("beam"));
+			ch->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(4, 2, nullptr), 0.f, "");
+			ch->add_layer<float>("hits", value, "counts");
+
+			SphericalVoxel& sph = ch->get_voxel_flat<SphericalVoxel>("angular", 0);
+			for (size_t i = 0; i < 8; i++)
+				sph.get_segments_data()[i] = value;
+
+			auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
+				Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
+					1000, "geom", "physics",
+					Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
+						glm::vec3(0, 0, -1), glm::vec3(0, 0, 1), 15000.f, "tube"
+					)
+				),
+				Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
+			);
+			return std::make_pair(field, metadata);
+		};
+
+		auto [field1, meta1] = create_field(3.f);
+		FieldStore::store(field1, meta1, "test_spherical_join.rf3");
+
+		auto [field2, meta2] = create_field(7.f);
+		FieldStore::join(field2, meta2, "test_spherical_join.rf3", FieldJoinMode::Add, FieldJoinCheckMode::NoChecks);
+
+		auto loaded = std::static_pointer_cast<CartesianRadiationField>(FieldStore::load("test_spherical_join.rf3"));
+		std::shared_ptr<VoxelGridBuffer> loaded_ch = std::static_pointer_cast<VoxelGridBuffer>(loaded->get_channel("beam"));
+
+		EXPECT_FLOAT_EQ(loaded_ch->get_voxel_flat<ScalarVoxel<float>>("hits", 0).get_data(), 10.f);
+
+		SphericalVoxel& loaded_sph = loaded_ch->get_voxel_flat<SphericalVoxel>("angular", 0);
+		EXPECT_EQ(loaded_sph.get_phi_segments(), 4);
+		EXPECT_EQ(loaded_sph.get_theta_segments(), 2);
+		for (size_t i = 0; i < 8; i++)
+			EXPECT_FLOAT_EQ(loaded_sph.get_segments_data()[i], 10.f);
+	}
+
+	TEST_F(SphericalVoxelStorage, Accessor) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.5f));
+		std::shared_ptr<VoxelGridBuffer> ch = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("beam"));
+		ch->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(6, 3, nullptr), 0.f, "");
+		ch->add_layer<float>("hits", 0.f, "counts");
+
+		SphericalVoxel& sph = ch->get_voxel<SphericalVoxel>("angular", 1, 1, 1);
+		for (size_t i = 0; i < 18; i++)
+			sph.get_segments_data()[i] = static_cast<float>(i + 1);
+		ch->get_voxel<ScalarVoxel<float>>("hits", 1, 1, 1) = 42.f;
+
+		auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
+				100, "geom", "physics",
+				Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
+					glm::vec3(0, 0, -1), glm::vec3(0, 0, 1), 15000.f, "tube"
+				)
+			),
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
+		);
+		FieldStore::store(field, metadata, "test_spherical_accessor.rf3");
+
+		// Full field load
+		auto loaded_field = std::static_pointer_cast<CartesianRadiationField>(FieldStore::load("test_spherical_accessor.rf3"));
+		std::shared_ptr<VoxelGridBuffer> loaded_ch = std::static_pointer_cast<VoxelGridBuffer>(loaded_field->get_channel("beam"));
+
+		SphericalVoxel& loaded_sph = loaded_ch->get_voxel<SphericalVoxel>("angular", 1, 1, 1);
+		EXPECT_EQ(loaded_sph.get_phi_segments(), 6);
+		EXPECT_EQ(loaded_sph.get_theta_segments(), 3);
+		for (size_t i = 0; i < 18; i++)
+			EXPECT_FLOAT_EQ(loaded_sph.get_segments_data()[i], static_cast<float>(i + 1));
+		EXPECT_FLOAT_EQ(loaded_ch->get_voxel<ScalarVoxel<float>>("hits", 1, 1, 1).get_data(), 42.f);
+
+		// Accessor with fresh stream (required pattern — see accessor_test.cpp)
+		{
+			std::ifstream stream1("test_spherical_accessor.rf3", std::ios::binary);
+			auto accessor = FieldStore::construct_accessor(stream1);
+			auto cartesian_accessor = std::dynamic_pointer_cast<Storage::V1::CartesianFieldAccessor>(accessor);
+			ASSERT_NE(cartesian_accessor, nullptr);
+
+			std::ifstream stream2("test_spherical_accessor.rf3", std::ios::binary);
+			auto loaded_channel_acc = cartesian_accessor->accessChannel(stream2, "beam");
+			ASSERT_NE(loaded_channel_acc, nullptr);
+			EXPECT_TRUE(loaded_channel_acc->has_layer("angular"));
+			SphericalVoxel& acc_sph = loaded_channel_acc->get_voxel_flat<SphericalVoxel>("angular", 7);
+			EXPECT_EQ(acc_sph.get_phi_segments(), 6);
+			for (size_t i = 0; i < 18; i++)
+				EXPECT_FLOAT_EQ(acc_sph.get_segments_data()[i], static_cast<float>(i + 1));
+
+			SphericalVoxel& acc_empty = loaded_channel_acc->get_voxel_flat<SphericalVoxel>("angular", 0);
+			float sum = 0.f;
+			for (auto val : acc_empty.get_segments_data()) sum += val;
+			EXPECT_FLOAT_EQ(sum, 0.f);
+		}
+	}
+
+	TEST_F(SphericalVoxelStorage, DynamicMetadata) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.5f));
+		field->add_channel("beam");
+
+		auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
+				100, "geom", "physics",
+				Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
+					glm::vec3(0, 0, -1), glm::vec3(0, 0, 1), 15000.f, "tube"
+				)
+			),
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
+		);
+
+		metadata->set_dynamic_custom_metadata<SphericalVoxel>("angular_reference", SphericalVoxel(8, 4, nullptr));
+		SphericalVoxel& meta_sph = metadata->get_dynamic_metadata<SphericalVoxel>("angular_reference");
+		EXPECT_EQ(meta_sph.get_phi_segments(), 8);
+		EXPECT_EQ(meta_sph.get_theta_segments(), 4);
+		for (size_t i = 0; i < 32; i++)
+			meta_sph.get_segments_data()[i] = static_cast<float>(i);
+
+		metadata->add_dynamic_metadata<float>("test_value", 3.14f);
+
+		FieldStore::store(field, metadata, "test_spherical_metadata.rf3");
+
+		auto loaded_metadata = std::dynamic_pointer_cast<V1::RadiationFieldMetadata>(FieldStore::load_metadata("test_spherical_metadata.rf3"));
+		ASSERT_NE(loaded_metadata, nullptr);
+
+		auto& loaded_float = loaded_metadata->get_dynamic_metadata<ScalarVoxel<float>>("test_value");
+		EXPECT_FLOAT_EQ(loaded_float.get_data(), 3.14f);
+
+		auto keys = loaded_metadata->get_dynamic_metadata_keys();
+		bool found_angular = false;
+		for (auto& key : keys)
+			if (key == "angular_reference") found_angular = true;
+		EXPECT_TRUE(found_angular);
+
+		SphericalVoxel& loaded_sph = loaded_metadata->get_dynamic_metadata<SphericalVoxel>("angular_reference");
+		EXPECT_EQ(loaded_sph.get_phi_segments(), 8);
+		EXPECT_EQ(loaded_sph.get_theta_segments(), 4);
+		for (size_t i = 0; i < 32; i++)
+			EXPECT_FLOAT_EQ(loaded_sph.get_segments_data()[i], static_cast<float>(i));
+	}
+
+	// Mixed voxel types in same channel — production uses SphericalVoxel + HistogramVoxel + float together
+	TEST_F(SphericalVoxelStorage, MixedCustomVoxelTypes) {
+		auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.5f));
+		std::shared_ptr<VoxelGridBuffer> ch = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("beam"));
+
+		ch->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(6, 3, nullptr), 0.f, "");
+		ch->add_custom_layer<HistogramVoxel>("spectrum", HistogramVoxel(16, 1000.f, nullptr), 0.f, "eV");
+		ch->add_layer<float>("hits", 0.f, "counts");
+		ch->add_layer<glm::vec3>("direction", glm::vec3(0.f), "direction");
+
+		// Set values in all layer types
+		ch->get_voxel<SphericalVoxel>("angular", 0, 0, 0).add_value(1.f, 0.5f, 7.f);
+		ch->get_voxel<HistogramVoxel>("spectrum", 0, 0, 0).get_histogram()[5] = 42.f;
+		ch->get_voxel<ScalarVoxel<float>>("hits", 0, 0, 0) = 100.f;
+		ch->get_voxel<ScalarVoxel<glm::vec3>>("direction", 0, 0, 0) = glm::vec3(1.f, 0.f, 0.f);
+
+		auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
+				100, "geom", "physics",
+				Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
+					glm::vec3(0, 0, -1), glm::vec3(0, 0, 1), 15000.f, "tube"
+				)
+			),
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
+		);
+		FieldStore::store(field, metadata, "test_spherical_mixed.rf3");
+
+		// Load and verify all types
+		auto loaded = std::static_pointer_cast<CartesianRadiationField>(FieldStore::load("test_spherical_mixed.rf3"));
+		std::shared_ptr<VoxelGridBuffer> loaded_ch = std::static_pointer_cast<VoxelGridBuffer>(loaded->get_channel("beam"));
+
+		EXPECT_FLOAT_EQ(loaded_ch->get_voxel<ScalarVoxel<float>>("hits", 0, 0, 0).get_data(), 100.f);
+		EXPECT_FLOAT_EQ(loaded_ch->get_voxel<HistogramVoxel>("spectrum", 0, 0, 0).get_histogram()[5], 42.f);
+		EXPECT_EQ(loaded_ch->get_voxel<HistogramVoxel>("spectrum", 0, 0, 0).get_bins(), 16);
+
+		SphericalVoxel& loaded_sph = loaded_ch->get_voxel<SphericalVoxel>("angular", 0, 0, 0);
+		EXPECT_EQ(loaded_sph.get_phi_segments(), 6);
+		EXPECT_EQ(loaded_sph.get_theta_segments(), 3);
+		float sph_sum = 0.f;
+		for (auto val : loaded_sph.get_segments_data()) sph_sum += val;
+		EXPECT_FLOAT_EQ(sph_sum, 7.f);
+
+		glm::vec3 loaded_dir = loaded_ch->get_voxel<ScalarVoxel<glm::vec3>>("direction", 0, 0, 0).get_data();
+		EXPECT_FLOAT_EQ(loaded_dir.x, 1.f);
+		EXPECT_FLOAT_EQ(loaded_dir.y, 0.f);
+		EXPECT_FLOAT_EQ(loaded_dir.z, 0.f);
+	}
 }

--- a/tests/spherical_test.cpp
+++ b/tests/spherical_test.cpp
@@ -1,0 +1,245 @@
+#include "RadFiled3D/Voxel.hpp"
+#include "RadFiled3D/RadiationField.hpp"
+#include "RadFiled3D/storage/RadiationFieldStore.hpp"
+#include "RadFiled3D/storage/Types.hpp"
+#include "gtest/gtest.h"
+#include <cmath>
+#include <fstream>
+#include <cstdio>
+#include <iostream>
+
+using namespace RadFiled3D;
+using namespace RadFiled3D::Storage;
+
+TEST(SphericalVoxelTest, Construction) {
+	float buffer[72] = { 0.f };
+	SphericalVoxel voxel(12, 6, buffer);
+
+	EXPECT_EQ(voxel.get_phi_segments(), 12);
+	EXPECT_EQ(voxel.get_theta_segments(), 6);
+	EXPECT_EQ(voxel.get_total_segments(), 72);
+	EXPECT_EQ(voxel.get_bytes(), sizeof(float) * 72);
+	EXPECT_EQ(voxel.get_type(), "spherical");
+}
+
+TEST(SphericalVoxelTest, DefaultConstruction) {
+	SphericalVoxel voxel;
+
+	EXPECT_EQ(voxel.get_phi_segments(), 0);
+	EXPECT_EQ(voxel.get_theta_segments(), 0);
+	EXPECT_EQ(voxel.get_total_segments(), 0);
+}
+
+TEST(SphericalVoxelTest, AccessByIndex) {
+	float buffer[72] = { 0.f };
+	SphericalVoxel voxel(12, 6, buffer);
+
+	// Use add_value to set data, then read back with get_value
+	buffer[2 * 12 + 3] = 0.5f;  // set raw buffer directly
+	EXPECT_FLOAT_EQ(voxel.get_value(3, 2), 0.5f);  // read through voxel
+}
+
+TEST(SphericalVoxelTest, AddValue) {
+	float buffer[72] = { 0.f };
+	SphericalVoxel voxel(12, 6, buffer);
+
+	voxel.add_value(1.0f, 0.5f, 3.0f);
+	// Verify the exact segment got the value
+	EXPECT_FLOAT_EQ(voxel.get_value_by_coord(1.0f, 0.5f), 3.0f);
+
+	// Verify total sum is correct (only one segment was written)
+	float sum = 0.f;
+	for (size_t i = 0; i < 72; i++)
+		sum += buffer[i];
+	EXPECT_FLOAT_EQ(sum, 3.0f);
+}
+
+
+TEST(SphericalVoxelTest, Clear) {
+	float buffer[4] = { 1.f, 3.f, 2.f, 4.f };
+	SphericalVoxel voxel(2, 2, buffer);
+
+	voxel.clear();
+	for (size_t i = 0; i < 4; i++)
+		EXPECT_FLOAT_EQ(buffer[i], 0.f);
+}
+
+TEST(SphericalVoxelTest, InplaceAdd) {
+	float buf_a[4] = { 1.f, 2.f, 3.f, 4.f };
+	float buf_b[4] = { 0.5f, 0.5f, 0.5f, 0.5f };
+	SphericalVoxel a(2, 2, buf_a);
+	SphericalVoxel b(2, 2, buf_b);
+
+	a += b;
+	EXPECT_FLOAT_EQ(buf_a[0], 1.5f);
+	EXPECT_FLOAT_EQ(buf_a[1], 2.5f);
+	EXPECT_FLOAT_EQ(buf_a[2], 3.5f);
+	EXPECT_FLOAT_EQ(buf_a[3], 4.5f);
+}
+
+TEST(SphericalVoxelTest, ScalarDivide) {
+	float buffer[4] = { 2.f, 4.f, 6.f, 8.f };
+	SphericalVoxel voxel(2, 2, buffer);
+
+	voxel /= 2.f;
+	EXPECT_FLOAT_EQ(buffer[0], 1.f);
+	EXPECT_FLOAT_EQ(buffer[1], 2.f);
+	EXPECT_FLOAT_EQ(buffer[2], 3.f);
+	EXPECT_FLOAT_EQ(buffer[3], 4.f);
+}
+
+TEST(SphericalVoxelTest, Header) {
+	float buffer[72] = { 0.f };
+	SphericalVoxel voxel(12, 6, buffer);
+
+	auto header = voxel.get_header();
+	EXPECT_EQ(header.header_bytes, sizeof(SphericalVoxel::SphericalDefinition));
+
+	SphericalVoxel::SphericalDefinition* def = (SphericalVoxel::SphericalDefinition*)header.header;
+	EXPECT_EQ(def->phi_segments, 12);
+	EXPECT_EQ(def->theta_segments, 6);
+}
+
+TEST(SphericalVoxelTest, InitFromHeader) {
+	SphericalVoxel voxel;
+	SphericalVoxel::SphericalDefinition def(8, 4);
+
+	voxel.init_from_header(&def);
+	EXPECT_EQ(voxel.get_phi_segments(), 8);
+	EXPECT_EQ(voxel.get_theta_segments(), 4);
+	EXPECT_EQ(voxel.get_total_segments(), 32);
+}
+
+TEST(SphericalVoxelTest, OwningConstruction) {
+	OwningSphericalVoxel voxel(12, 6);
+
+	EXPECT_EQ(voxel.get_phi_segments(), 12);
+	EXPECT_EQ(voxel.get_total_segments(), 72);
+	EXPECT_NE(voxel.get_raw(), nullptr);
+
+	// Should be zero-initialized or at least accessible
+	voxel.add_value(1.0f, 0.5f, 5.0f);
+	float sum = 0.f;
+	for (auto val : voxel.get_segments_data())
+		sum += val;
+	EXPECT_FLOAT_EQ(sum, 5.0f);
+}
+
+TEST(SphericalVoxelTest, OwningCopy) {
+	OwningSphericalVoxel a(2, 2);
+	float* a_data = (float*)a.get_raw();
+	a_data[0] = 1.f; a_data[1] = 2.f; a_data[2] = 3.f; a_data[3] = 4.f;
+
+	OwningSphericalVoxel b(a);
+	float* b_data = (float*)b.get_raw();
+
+	// Data should be equal but at different addresses
+	EXPECT_NE(a_data, b_data);
+	EXPECT_FLOAT_EQ(b_data[0], 1.f);
+	EXPECT_FLOAT_EQ(b_data[3], 4.f);
+}
+
+TEST(SphericalVoxelTest, StoreAndLoad) {
+	const std::string filename = "test_spherical.rf3";
+
+	// Create a field with a spherical layer
+	auto field = std::make_shared<CartesianRadiationField>(glm::vec3(1.f), glm::vec3(0.1f));
+	std::shared_ptr<VoxelGridBuffer> channel = std::static_pointer_cast<VoxelGridBuffer>(field->add_channel("test_channel"));
+
+	// Add a spherical layer with 12 phi x 6 theta segments
+	channel->add_custom_layer<SphericalVoxel>("angular", SphericalVoxel(12, 6, nullptr), 0.f, "");
+	// Also add a simple float layer to verify mixed types work
+	channel->add_layer<float>("doserate", 0.f, "Gy/s");
+
+	// Set some values in the spherical layer
+	SphericalVoxel& sph = channel->get_voxel<SphericalVoxel>("angular", 0, 5, 0);
+	for (size_t i = 0; i < 72; i++)
+		sph.get_segments_data()[i] = static_cast<float>(i);
+
+	// Set a value on the diagonal
+	for (size_t x = 0; x < 10; x++) {
+		SphericalVoxel& diag = channel->get_voxel<SphericalVoxel>("angular", x, x, x);
+		for (size_t i = 0; i < 72; i++)
+			diag.get_segments_data()[i] = 99.f;
+	}
+
+	// Set doserate too
+	channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0) = 42.f;
+
+	// --- Print before store ---
+	std::cout << "\n=== BEFORE STORE ===" << std::endl;
+	std::cout << "Field: " << field->get_voxel_counts().x << "x" << field->get_voxel_counts().y << "x" << field->get_voxel_counts().z << " voxels" << std::endl;
+	std::cout << "Voxel dimensions: " << field->get_voxel_dimensions().x << "m" << std::endl;
+	std::cout << "Channels: ";
+	for (auto& ch : field->get_channels()) std::cout << ch.first << " ";
+	std::cout << std::endl;
+	std::cout << "Layers: angular (spherical " << sph.get_phi_segments() << "x" << sph.get_theta_segments() << "), doserate (float)" << std::endl;
+	std::cout << "\nVoxel (0,5,0) angular - first 12 segments (phi row 0):" << std::endl;
+	for (size_t i = 0; i < 12; i++)
+		std::cout << "  [phi=" << i << ",theta=0] = " << sph.get_segments_data()[i] << std::endl;
+	std::cout << "Voxel (0,5,0) doserate = " << channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0).get_data() << std::endl;
+	std::cout << "\nDiagonal voxel (3,3,3) angular - first 6 segments:" << std::endl;
+	SphericalVoxel& diag_print = channel->get_voxel<SphericalVoxel>("angular", 3, 3, 3);
+	for (size_t i = 0; i < 6; i++)
+		std::cout << "  [" << i << "] = " << diag_print.get_segments_data()[i] << std::endl;
+
+	// Create metadata and store
+	auto metadata = std::make_shared<V1::RadiationFieldMetadata>(
+		Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation(
+			1000, "test_geom", "test_physics",
+			Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Simulation::XRayTube(
+				glm::vec3(0.f, 0.f, -1.f), glm::vec3(0.f, 0.f, 1.f), 15000.f, "test_tube"
+			)
+		),
+		Storage::FiledTypes::V1::RadiationFieldMetadataHeader::Software("test", "1.0", "", "")
+	);
+
+	FieldStore::store(field, metadata, filename);
+
+	// Load and verify
+	auto loaded_field = std::static_pointer_cast<CartesianRadiationField>(FieldStore::load(filename));
+	EXPECT_EQ(loaded_field->get_voxel_counts(), glm::uvec3(10));
+
+	std::shared_ptr<VoxelGridBuffer> loaded_channel = std::static_pointer_cast<VoxelGridBuffer>(loaded_field->get_channel("test_channel"));
+
+	// --- Print after load ---
+	std::cout << "\n=== AFTER LOAD ===" << std::endl;
+	std::cout << "Field: " << loaded_field->get_voxel_counts().x << "x" << loaded_field->get_voxel_counts().y << "x" << loaded_field->get_voxel_counts().z << " voxels" << std::endl;
+	std::cout << "Layers in channel: ";
+	for (auto& l : loaded_channel->get_layers()) std::cout << l << " ";
+	std::cout << std::endl;
+
+	// Verify doserate
+	float loaded_doserate = loaded_channel->get_voxel<ScalarVoxel<float>>("doserate", 0, 5, 0).get_data();
+	std::cout << "\nVoxel (0,5,0) doserate = " << loaded_doserate << std::endl;
+	EXPECT_FLOAT_EQ(loaded_doserate, 42.f);
+
+	// Verify spherical voxel at (0,5,0)
+	SphericalVoxel& loaded_sph = loaded_channel->get_voxel<SphericalVoxel>("angular", 0, 5, 0);
+	std::cout << "Voxel (0,5,0) angular: phi_segments=" << loaded_sph.get_phi_segments() << " theta_segments=" << loaded_sph.get_theta_segments() << std::endl;
+	std::cout << "Voxel (0,5,0) angular - first 12 segments (phi row 0):" << std::endl;
+	for (size_t i = 0; i < 12; i++)
+		std::cout << "  [phi=" << i << ",theta=0] = " << loaded_sph.get_segments_data()[i] << std::endl;
+
+	EXPECT_EQ(loaded_sph.get_phi_segments(), 12);
+	EXPECT_EQ(loaded_sph.get_theta_segments(), 6);
+	for (size_t i = 0; i < 72; i++)
+		EXPECT_FLOAT_EQ(loaded_sph.get_segments_data()[i], static_cast<float>(i));
+
+	// Verify diagonal voxels
+	std::cout << "\nDiagonal voxel (3,3,3) angular - first 6 segments:" << std::endl;
+	SphericalVoxel& loaded_diag_print = loaded_channel->get_voxel<SphericalVoxel>("angular", 3, 3, 3);
+	for (size_t i = 0; i < 6; i++)
+		std::cout << "  [" << i << "] = " << loaded_diag_print.get_segments_data()[i] << std::endl;
+
+	for (size_t x = 0; x < 10; x++) {
+		SphericalVoxel& loaded_diag = loaded_channel->get_voxel<SphericalVoxel>("angular", x, x, x);
+		for (size_t i = 0; i < 72; i++)
+			EXPECT_FLOAT_EQ(loaded_diag.get_segments_data()[i], 99.f);
+	}
+
+	std::cout << "\n=== STORE/LOAD MATCH ===" << std::endl;
+
+	// Cleanup
+	std::remove(filename.c_str());
+}

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -1,0 +1,115 @@
+from RadFiled3D.RadFiled3D import CartesianRadiationField, vec3, DType, SphericalVoxel, OwningSphericalVoxel
+from RadFiled3D.utils import FieldStore, StoreVersion
+from RadFiled3D.metadata.v1 import Metadata
+import numpy as np
+import os
+
+
+def test_spherical_voxel_creation():
+    """Test creating a field with a SphericalVoxel layer and accessing it."""
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 12, 6, "")
+
+    sph = ch.get_voxel_flat("angular", 0)
+    assert isinstance(sph, SphericalVoxel)
+    assert sph.get_phi_segments() == 12
+    assert sph.get_theta_segments() == 6
+    assert sph.get_total_segments() == 72
+
+
+def test_spherical_numpy_export_flat():
+    """Test that get_segments_data returns a valid flat numpy array."""
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 6, 3, "")
+
+    sph = ch.get_voxel_flat("angular", 0)
+    sph.add_value(1.0, 0.5, 5.0)
+
+    data = sph.get_segments_data()
+    assert isinstance(data, np.ndarray)
+    assert data.dtype == np.float32
+    assert data.shape[0] == 18
+    assert data.sum() == 5.0
+
+
+def test_spherical_numpy_export_2d():
+    """Test that get_data returns a 2D numpy array with correct shape (theta, phi)."""
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 12, 6, "")
+
+    sph = ch.get_voxel_flat("angular", 0)
+    sph.add_value(1.0, 0.5, 7.0)
+
+    data = sph.get_data()
+    assert isinstance(data, np.ndarray)
+    assert data.dtype == np.float32
+    # Shape is (phi, theta, 1) due to create_py_array_generic components dimension
+    assert data.shape[0] == 12  # phi
+    assert data.shape[1] == 6   # theta
+    assert data.sum() == 7.0
+
+
+def test_spherical_store_and_load():
+    """Test that SphericalVoxel data survives store/load roundtrip."""
+    filename = "test_spherical_py.rf3"
+
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 8, 4, "")
+    ch.add_layer("hits", "counts", DType.FLOAT32)
+
+    sph = ch.get_voxel_flat("angular", 0)
+    for i in range(32):
+        sph.get_segments_data()[i] = float(i)
+
+    metadata = Metadata.default()
+    FieldStore.store(field, metadata, filename, StoreVersion.V1)
+
+    loaded = FieldStore.load(filename)
+    loaded_ch = loaded.get_channel("beam")
+    loaded_sph = loaded_ch.get_voxel_flat("angular", 0)
+
+    assert loaded_sph.get_phi_segments() == 8
+    assert loaded_sph.get_theta_segments() == 4
+
+    loaded_data = loaded_sph.get_segments_data()
+    for i in range(32):
+        assert loaded_data[i] == float(i), f"Mismatch at index {i}: {loaded_data[i]} != {float(i)}"
+
+    os.remove(filename)
+
+
+def test_spherical_memory_safety():
+    """Test that numpy arrays remain valid after the field goes out of scope."""
+    def get_data():
+        field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+        field.add_channel("beam")
+        ch = field.get_channel("beam")
+        ch.add_spherical_layer("angular", 6, 3, "")
+        sph = ch.get_voxel_flat("angular", 0)
+        sph.add_value(1.0, 0.5, 42.0)
+        return sph.get_segments_data()
+
+    data = get_data()
+    assert data.sum() == 42.0
+    assert data.shape[0] == 18
+
+
+def test_owning_spherical_voxel():
+    """Test OwningSphericalVoxel creation and numpy export."""
+    voxel = OwningSphericalVoxel(12, 6)
+    assert voxel.get_phi_segments() == 12
+    assert voxel.get_theta_segments() == 6
+    assert voxel.get_total_segments() == 72
+
+    voxel.add_value(1.0, 0.5, 3.0)
+    data = voxel.get_segments_data()
+    assert isinstance(data, np.ndarray)
+    assert data.sum() == 3.0


### PR DESCRIPTION
## Summary
- Adds `SphericalVoxel` — a new voxel type that stores angular radiation distribution per voxel using spherical segments (phi × theta grid)
- Analogous to `HistogramVoxel` (1D energy spectrum), `SphericalVoxel` provides a 2D directional distribution on the unit sphere
- Enables capturing **from which directions** radiation arrives at each voxel, instead of only a single averaged direction vector

## Changes

**New voxel type (`Voxel.hpp`):**
- `SphericalVoxel` with configurable phi × theta resolution (e.g. 12×6 = 72 segments)
- Linear mapping: phi ∈ [0, 2π], theta ∈ [0, π] with equal angular bin width
- `OwningSphericalVoxel` for standalone instances with own memory
- Full operator support (`+=`, `-=`, `*=`, `/=` for both voxel and scalar)

**Type system (`Typing.hpp/cpp`):**
- New `DType::Spherical` enum value
- String mapping `"spherical"` ↔ `DType::Spherical`

**Serialization (`FieldSerializer.cpp/hpp`):**
- Serialize/deserialize support for SphericalVoxel layers
- Header stores phi/theta segment counts, data stored as flat float array

**VoxelBuffer operators (`VoxelBuffer.cpp`):**
- 8 new switch-cases for Spherical in all arithmetic operators (VoxelBuffer and scalar variants)

**Field join (`RadiationFieldStore.cpp`):**
- SphericalVoxel support in `FieldStore::join()` for merging simulation runs

**Accessor (`FieldAccessor.cpp`):**
- Lazy-loading support for SphericalVoxel via `createVoxelFromBuffer`

**Python bindings (`bindings.cpp`):**
- `SphericalVoxel` and `OwningSphericalVoxel` exposed to Python
- `get_data()` returns 2D numpy array (theta × phi)
- `get_segments_data()` returns flat numpy array
- All voxel access methods support Spherical type

**Tests (`spherical_test.cpp`):**
- 19 tests covering construction, operators, serialization, field copy, buffer operators, 3D grid access, field join, accessor loading, dynamic metadata, and mixed voxel types