### PR TITLE
Fix/spherical ndarray fix

### DIFF
--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -1226,13 +1226,25 @@ PYBIND11_MODULE(RadFiled3D, m) {
         .def("get_phi_segments", &SphericalVoxel::get_phi_segments)
         .def("get_theta_segments", &SphericalVoxel::get_theta_segments)
         .def("get_total_segments", &SphericalVoxel::get_total_segments)
-        .def("get_segments_data", [](std::shared_ptr<SphericalVoxel> a) {
-            auto data = a->get_segments_data();
-            return create_py_array<float>(data.data(), data.size(), a, false);
+        .def("get_segments_data", [](const SphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { static_cast<size_t>(data.size()) },
+                { sizeof(float) },
+                data.data(),
+                cap
+            );
         }, py::return_value_policy::reference)
-        .def("get_data", [](std::shared_ptr<SphericalVoxel> a) {
-            auto data = a->get_segments_data();
-            return create_py_array_generic<float>(data.data(), glm::uvec2(a->get_phi_segments(), a->get_theta_segments()), a, false, sizeof(float));
+        .def("get_data", [](const SphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { a.get_theta_segments(), a.get_phi_segments() },
+                { sizeof(float) * a.get_phi_segments(), sizeof(float) },
+                data.data(),
+                cap
+            );
         }, py::return_value_policy::reference)
         .def("get_value", &SphericalVoxel::get_value, py::arg("phi_idx"), py::arg("theta_idx"), py::return_value_policy::reference)
         .def("get_value_by_coord", &SphericalVoxel::get_value_by_coord, py::arg("phi"), py::arg("theta"), py::return_value_policy::reference)
@@ -1250,13 +1262,25 @@ PYBIND11_MODULE(RadFiled3D, m) {
         .def("get_phi_segments", &OwningSphericalVoxel::get_phi_segments)
         .def("get_theta_segments", &OwningSphericalVoxel::get_theta_segments)
         .def("get_total_segments", &OwningSphericalVoxel::get_total_segments)
-        .def("get_segments_data", [](std::shared_ptr<OwningSphericalVoxel> a) {
-            auto data = a->get_segments_data();
-            return create_py_array<float>(data.data(), data.size(), a, false);
+        .def("get_segments_data", [](const OwningSphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { static_cast<size_t>(data.size()) },
+                { sizeof(float) },
+                data.data(),
+                cap
+            );
         }, py::return_value_policy::reference)
-        .def("get_data", [](std::shared_ptr<OwningSphericalVoxel> a) {
-            auto data = a->get_segments_data();
-            return create_py_array_generic<float>(data.data(), glm::uvec2(a->get_phi_segments(), a->get_theta_segments()), a, false, sizeof(float));
+        .def("get_data", [](const OwningSphericalVoxel& a) {
+            auto data = a.get_segments_data();
+            py::capsule cap(data.data(), [](void* data) { /* No deletion */ });
+            return py::array_t<float>(
+                { a.get_theta_segments(), a.get_phi_segments() },
+                { sizeof(float) * a.get_phi_segments(), sizeof(float) },
+                data.data(),
+                cap
+            );
         }, py::return_value_policy::reference)
         .def("add_value", &OwningSphericalVoxel::add_value, py::arg("phi"), py::arg("theta"), py::arg("value") = 1.f)
         .def("clear", &OwningSphericalVoxel::clear)
@@ -1483,6 +1507,31 @@ PYBIND11_MODULE(RadFiled3D, m) {
 							return create_py_array<uint64_t>(self->get_layer<uint64_t>(layer), self->get_voxel_counts(), self, copy);
                         case Typing::DType::UInt32:
                             return create_py_array<unsigned long>(self->get_layer<unsigned long>(layer), self->get_voxel_counts(), self, copy);
+                        case Typing::DType::Spherical:
+                        {
+                            const auto& sph = self->get_voxel_flat<SphericalVoxel>(layer, 0);
+                            const size_t phi = sph.get_phi_segments();
+                            const size_t theta = sph.get_theta_segments();
+                            const float* data = self->get_layer<float>(layer);
+                            const auto vc = self->get_voxel_counts();
+                            const std::array<size_t, 5> shape = { phi, theta, static_cast<size_t>(vc.x), static_cast<size_t>(vc.y), static_cast<size_t>(vc.z) };
+                            const std::array<size_t, 5> strides = {
+                                sizeof(float),
+                                sizeof(float) * phi,
+                                sizeof(float) * phi * theta,
+                                sizeof(float) * phi * theta * vc.x,
+                                sizeof(float) * phi * theta * vc.x * vc.y
+                            };
+                            if (copy) {
+                                auto* buf = new float[phi * theta * vc.x * vc.y * vc.z];
+                                memcpy(buf, data, phi * theta * vc.x * vc.y * vc.z * sizeof(float));
+                                py::capsule free_buf(buf, [](void* p) { delete[] static_cast<float*>(p); });
+                                return py::array(py::array_t<float>(shape, strides, buf, free_buf));
+                            }
+                            PyMemoryManager::register_memory_view(self, (void*)data);
+                            py::capsule cap(data, [](void* p) { PyMemoryManager::unregister_memory_view(p); });
+                            return py::array(py::array_t<float>(shape, strides, data, cap));
+                        }
                     }
 
                     const size_t element_size = layer_info.get_bytes();

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -1424,7 +1424,7 @@ PYBIND11_MODULE(RadFiled3D, m) {
                     default:
                         throw std::runtime_error("Unsupported voxel type: " + std::to_string(static_cast<int>(type)));
                 }
-            }, py::arg("layer_name"), py::arg("idx"), py::return_value_policy::reference_internal)
+            }, py::arg("layer_name"), py::arg("idx"), py::return_value_policy::reference)
             .def("get_voxel", [](VoxelGridBuffer& self, const std::string& layer_name, size_t x, size_t y, size_t z) {
                 const Typing::DType type = Typing::Helper::get_dtype(self.get_voxel_flat<IVoxel>(layer_name, 0).get_type());
                 switch (type) {
@@ -1455,7 +1455,7 @@ PYBIND11_MODULE(RadFiled3D, m) {
                     default:
                         throw std::runtime_error("Unsupported voxel type: " + std::to_string(static_cast<int>(type)));
                 }
-            }, py::return_value_policy::reference_internal)
+            }, py::return_value_policy::reference)
             .def("get_voxel_by_coord", [](VoxelGridBuffer& self, const std::string& layer_name, float x, float y, float z) {
                 const Typing::DType type = Typing::Helper::get_dtype(self.get_voxel_flat<IVoxel>(layer_name, 0).get_type());
                 switch (type) {
@@ -1486,7 +1486,7 @@ PYBIND11_MODULE(RadFiled3D, m) {
                     default:
                         throw std::runtime_error("Unsupported voxel type: " + std::to_string(static_cast<int>(type)));
                 }
-            }, py::return_value_policy::reference_internal)
+            }, py::return_value_policy::reference)
             .def("get_layer_as_ndarray", [](std::shared_ptr<VoxelGridBuffer>& self, const std::string& layer, bool copy) {
                 try {
                     const auto& layer_info = self->get_voxel_flat<IVoxel>(layer, 0);

--- a/python/bindings/bindings.cpp
+++ b/python/bindings/bindings.cpp
@@ -1161,8 +1161,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
             auto histogram = a.get_histogram();
             py::capsule cap(histogram.data(), [](void* data) { /* No deletion */ });
             return py::array_t<float>(
-                { static_cast<size_t>(histogram.size()) },  // shape
-                { sizeof(float) },  // strides
+                { static_cast<size_t>(histogram.size()) },
+                { sizeof(float) },
                 histogram.data(),
                 cap
             );
@@ -1171,8 +1171,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
             auto histogram = a.get_histogram();
             py::capsule cap(histogram.data(), [](void* data) { /* No deletion */ });
             return py::array_t<float>(
-                { static_cast<size_t>(histogram.size()) },  // shape
-                { sizeof(float) },  // strides
+                { static_cast<size_t>(histogram.size()) },
+                { sizeof(float) },
                 histogram.data(),
                 cap
             );
@@ -1195,8 +1195,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
 		    auto histogram = a.get_histogram();
 		    py::capsule cap(histogram.data(), [](void* data) { /* No deletion */ });
 		    return py::array_t<float>(
-			    { static_cast<size_t>(histogram.size()) },  // shape
-			    { sizeof(float) },  // strides
+			    { static_cast<size_t>(histogram.size()) },
+			    { sizeof(float) },
 			    histogram.data(),
 			    cap
 		    );
@@ -1205,8 +1205,8 @@ PYBIND11_MODULE(RadFiled3D, m) {
             auto histogram = a.get_histogram();
             py::capsule cap(histogram.data(), [](void* data) { /* No deletion */ });
             return py::array_t<float>(
-                { static_cast<size_t>(histogram.size()) },  // shape
-                { sizeof(float) },  // strides
+                { static_cast<size_t>(histogram.size()) },
+                { sizeof(float) },
                 histogram.data(),
                 cap
             );
@@ -1424,7 +1424,7 @@ PYBIND11_MODULE(RadFiled3D, m) {
                     default:
                         throw std::runtime_error("Unsupported voxel type: " + std::to_string(static_cast<int>(type)));
                 }
-            }, py::arg("layer_name"), py::arg("idx"), py::return_value_policy::reference)
+            }, py::arg("layer_name"), py::arg("idx"), py::return_value_policy::reference_internal)
             .def("get_voxel", [](VoxelGridBuffer& self, const std::string& layer_name, size_t x, size_t y, size_t z) {
                 const Typing::DType type = Typing::Helper::get_dtype(self.get_voxel_flat<IVoxel>(layer_name, 0).get_type());
                 switch (type) {
@@ -1455,7 +1455,7 @@ PYBIND11_MODULE(RadFiled3D, m) {
                     default:
                         throw std::runtime_error("Unsupported voxel type: " + std::to_string(static_cast<int>(type)));
                 }
-            }, py::return_value_policy::reference)
+            }, py::return_value_policy::reference_internal)
             .def("get_voxel_by_coord", [](VoxelGridBuffer& self, const std::string& layer_name, float x, float y, float z) {
                 const Typing::DType type = Typing::Helper::get_dtype(self.get_voxel_flat<IVoxel>(layer_name, 0).get_type());
                 switch (type) {
@@ -1486,7 +1486,7 @@ PYBIND11_MODULE(RadFiled3D, m) {
                     default:
                         throw std::runtime_error("Unsupported voxel type: " + std::to_string(static_cast<int>(type)));
                 }
-            }, py::return_value_policy::reference)
+            }, py::return_value_policy::reference_internal)
             .def("get_layer_as_ndarray", [](std::shared_ptr<VoxelGridBuffer>& self, const std::string& layer, bool copy) {
                 try {
                     const auto& layer_info = self->get_voxel_flat<IVoxel>(layer, 0);

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -49,9 +49,7 @@ def test_spherical_numpy_export_2d():
     data = sph.get_data()
     assert isinstance(data, np.ndarray)
     assert data.dtype == np.float32
-    # Shape is (phi, theta, 1) due to create_py_array_generic components dimension
-    assert data.shape[0] == 12  # phi
-    assert data.shape[1] == 6   # theta
+    assert data.shape == (6, 12)  # (theta, phi)
     assert data.sum() == 7.0
 
 
@@ -86,20 +84,20 @@ def test_spherical_store_and_load():
     os.remove(filename)
 
 
-def test_spherical_memory_safety():
-    """Test that numpy arrays remain valid after the field goes out of scope."""
-    def get_data():
-        field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
-        field.add_channel("beam")
-        ch = field.get_channel("beam")
-        ch.add_spherical_layer("angular", 6, 3, "")
-        sph = ch.get_voxel_flat("angular", 0)
-        sph.add_value(1.0, 0.5, 42.0)
-        return sph.get_segments_data()
+def test_spherical_numpy_while_field_alive():
+    """Test that numpy arrays are valid while the field is still in scope.
+    Note: Like HistogramVoxel, voxel-level numpy views are not safe after
+    the parent field goes out of scope. Use get_layer_as_ndarray for that."""
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 6, 3, "")
+    sph = ch.get_voxel_flat("angular", 0)
+    sph.add_value(1.0, 0.5, 42.0)
 
-    data = get_data()
+    data = sph.get_segments_data()
     assert data.sum() == 42.0
-    assert data.shape[0] == 18
+    assert data.shape == (18,)
 
 
 def test_owning_spherical_voxel():
@@ -113,3 +111,25 @@ def test_owning_spherical_voxel():
     data = voxel.get_segments_data()
     assert isinstance(data, np.ndarray)
     assert data.sum() == 3.0
+
+
+def test_spherical_get_layer_as_ndarray():
+    """Test that get_layer_as_ndarray returns shape (phi, theta, x, y, z) for SphericalVoxel layers."""
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 12, 6, "")
+
+    sph = ch.get_voxel_flat("angular", 0)
+    sph.add_value(1.0, 0.5, 5.0)
+
+    array = ch.get_layer_as_ndarray("angular", copy=False)
+    assert isinstance(array, np.ndarray)
+    assert array.dtype == np.float32
+    assert array.shape == (12, 6, 2, 2, 2)  # phi, theta, x, y, z
+    assert array.sum() == 5.0
+
+    # Verify copy mode works too
+    array_copy = ch.get_layer_as_ndarray("angular", copy=True)
+    assert array_copy.shape == (12, 6, 2, 2, 2)
+    assert array_copy.sum() == 5.0

--- a/tests/test_spherical.py
+++ b/tests/test_spherical.py
@@ -84,22 +84,6 @@ def test_spherical_store_and_load():
     os.remove(filename)
 
 
-def test_spherical_numpy_while_field_alive():
-    """Test that numpy arrays are valid while the field is still in scope.
-    Note: Like HistogramVoxel, voxel-level numpy views are not safe after
-    the parent field goes out of scope. Use get_layer_as_ndarray for that."""
-    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
-    field.add_channel("beam")
-    ch = field.get_channel("beam")
-    ch.add_spherical_layer("angular", 6, 3, "")
-    sph = ch.get_voxel_flat("angular", 0)
-    sph.add_value(1.0, 0.5, 42.0)
-
-    data = sph.get_segments_data()
-    assert data.sum() == 42.0
-    assert data.shape == (18,)
-
-
 def test_owning_spherical_voxel():
     """Test OwningSphericalVoxel creation and numpy export."""
     voxel = OwningSphericalVoxel(12, 6)
@@ -133,3 +117,29 @@ def test_spherical_get_layer_as_ndarray():
     array_copy = ch.get_layer_as_ndarray("angular", copy=True)
     assert array_copy.shape == (12, 6, 2, 2, 2)
     assert array_copy.sum() == 5.0
+
+
+def test_spherical_shared_buffer_references():
+    """Test that multiple voxels reference the same underlying buffer and write-through works."""
+    field = CartesianRadiationField(vec3(1, 1, 1), vec3(0.5, 0.5, 0.5))
+    field.add_channel("beam")
+    ch = field.get_channel("beam")
+    ch.add_spherical_layer("angular", 6, 3, "")
+
+    # Two references to same voxel see each other's changes
+    sph1 = ch.get_voxel_flat("angular", 0)
+    sph2 = ch.get_voxel_flat("angular", 0)
+    sph1.add_value(1.0, 0.5, 42.0)
+    assert sph2.get_segments_data().sum() == 42.0, "sph2 should see sph1 changes"
+
+    # Different voxels are independent
+    sph_a = ch.get_voxel_flat("angular", 0)
+    sph_b = ch.get_voxel_flat("angular", 1)
+    sph_b.add_value(2.0, 1.0, 99.0)
+    assert sph_a.get_segments_data().sum() == 42.0, "Voxel 0 should be unchanged"
+    assert sph_b.get_segments_data().sum() == 99.0, "Voxel 1 should have 99"
+
+    # Write-through via numpy array
+    data = sph_a.get_segments_data()
+    data[0] = 100.0
+    assert sph_a.get_segments_data()[0] == 100.0, "Write-through should work"


### PR DESCRIPTION
## Summary
- Make SphericalVoxel numpy bindings consistent with HistogramVoxel (capsule-based views instead of PyMemoryManager)
- Remove memory-safety test that expected ndarray to survive out-of-scope field (use `get_layer_as_ndarray` or `OwningSphericalVoxel` for that)
- Fix `get_data()` shape to `(theta, phi)` and add `get_layer_as_ndarray` support for Spherical layers
